### PR TITLE
Add LANGSMITH_PROJECT guidance to all LangSmith skills

### DIFF
--- a/config/skills/langsmith-dataset/SKILL.md
+++ b/config/skills/langsmith-dataset/SKILL.md
@@ -12,8 +12,11 @@ Environment Variables
 
 ```bash
 LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # Required
+LANGSMITH_PROJECT=your-project-name                   # Check this to know which project has traces
 LANGSMITH_WORKSPACE_ID=your-workspace-id              # Optional: for org-scoped keys
 ```
+
+**IMPORTANT:** Always check the environment variables or `.env` file for `LANGSMITH_PROJECT` before querying or interacting with LangSmith. This tells you which project contains the relevant traces and data. If the LangSmith project is not available, use your best judgement to identify the right one.
 
 Python Dependencies
 ```bash
@@ -289,3 +292,4 @@ langsmith experiment list --dataset "Skills: Final Response"
 - Use `langsmith dataset get "Name"` to check remote count
 - Compare with local file to verify upload completeness
 </troubleshooting>
+</output>

--- a/config/skills/langsmith-evaluator/SKILL.md
+++ b/config/skills/langsmith-evaluator/SKILL.md
@@ -12,9 +12,12 @@ Environment Variables
 
 ```bash
 LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # Required
+LANGSMITH_PROJECT=your-project-name                   # Check this to know which project has traces
 LANGSMITH_WORKSPACE_ID=your-workspace-id              # Optional: for org-scoped keys
 OPENAI_API_KEY=your_openai_key                        # For LLM as Judge
 ```
+
+**IMPORTANT:** Always check the environment variables or `.env` file for `LANGSMITH_PROJECT` before querying or interacting with LangSmith. This tells you which project contains the relevant traces and data. If the LangSmith project is not available, use your best judgement to identify the right one.
 
 Python Dependencies
 ```bash

--- a/config/skills/langsmith-trace/SKILL.md
+++ b/config/skills/langsmith-trace/SKILL.md
@@ -16,6 +16,8 @@ LANGSMITH_PROJECT=your-project-name                   # Optional: default projec
 LANGSMITH_WORKSPACE_ID=your-workspace-id              # Optional: for org-scoped keys
 ```
 
+**IMPORTANT:** Always check the environment variables or `.env` file for `LANGSMITH_PROJECT` before querying or interacting with LangSmith. This tells you which project contains the relevant traces and data. If the LangSmith project is not available, use your best judgement to identify the right one.
+
 CLI Tool
 ```bash
 curl -sSL https://raw.githubusercontent.com/langchain-ai/langsmith-cli/main/scripts/install.sh | sh


### PR DESCRIPTION
## Summary
- Adds `LANGSMITH_PROJECT` env var to langsmith-dataset and langsmith-evaluator setup sections (langsmith-trace already had it)
- Adds callout paragraph to all 3 skills instructing Claude to check environment variables for `LANGSMITH_PROJECT` before querying LangSmith
- Prevents Claude from listing projects and picking one randomly instead of using the configured project

## Context
This was validated in our benchmarks repo (PR #117). Without this guidance, Claude would sometimes ignore the configured project and pick a random one from the LangSmith workspace, causing task failures.

## Test plan
- [x] Verified in benchmarks repo with ls-multiskill-basic and ls-multiskill-advanced tasks (100% pass rate with guidance vs failures without)
- [x] Content matches the definitive versions in the benchmarks skills repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)