### PR TITLE
feat: add autoresearch for agents example with langsmith evals

### DIFF
--- a/examples/autoresearch/README.md
+++ b/examples/autoresearch/README.md
@@ -13,12 +13,13 @@ Give an AI coding agent a working agent implementation and an evaluation dataset
 │  1. Read agent.py + results so far                   │
 │  2. Propose a change (prompt, tools, architecture)   │
 │  3. Edit agent.py                                    │
-│  4. Run evaluation: python run_eval.py               │
-│  5. Parse scores from eval output                    │
-│  6. If improved → git commit (keep)                  │
+│  4. git commit                                       │
+│  5. Run evaluation: python run_eval.py               │
+│  6. Parse scores from eval output                    │
+│  7. If improved → keep commit                        │
 │     If worse   → git reset  (discard)                │
-│  7. Log result to results.tsv                        │
-│  8. Repeat forever                                   │
+│  8. Log result to results.tsv                        │
+│  9. Repeat forever                                   │
 │                                                      │
 └─────────────────────────────────────────────────────┘
 ```

--- a/examples/autoresearch/README.md
+++ b/examples/autoresearch/README.md
@@ -75,13 +75,56 @@ python run_eval.py
 
 ### Running the Autonomous Agent
 
-Point your coding agent (Claude Code, Cursor, Codex, etc.) at this directory and prompt:
+Point your coding agent (Claude Code, Cursor, Codex, etc.) at this directory and send this prompt:
+
+<details>
+<summary><b>📋 Copy-paste prompt for Claude Code / Cursor / Codex</b></summary>
 
 ```
-Read program.md and let's kick off a new experiment! Do the setup first.
+I want you to autonomously optimize an AI agent using an eval-driven experiment loop.
+
+Here's how it works:
+- `agent.py` is the agent implementation. This is the ONLY file you modify.
+- `run_eval.py` is the evaluation harness. It runs the agent against a fixed dataset
+  and scores it using LangSmith. Do NOT modify this file.
+- `dataset.json` is the evaluation dataset. Do NOT modify this file.
+- `program.md` has detailed instructions for the experiment loop.
+
+Read program.md now and follow the setup instructions. Once setup is confirmed,
+start the experiment loop and run autonomously — do not stop to ask me questions.
+Keep experimenting until I interrupt you.
 ```
 
-The coding agent will then autonomously iterate on `agent.py`, running evals and tracking results.
+</details>
+
+The coding agent will then autonomously iterate on `agent.py`, running evals and tracking results. You can walk away and come back to a log of experiments in `results.tsv` and all traces in LangSmith.
+
+#### First time here? Use this prompt instead to set everything up from scratch:
+
+<details>
+<summary><b>📋 Copy-paste setup + run prompt</b></summary>
+
+```
+I want to set up and run autoresearch for agents — an autonomous experiment loop
+that optimizes an AI agent using LangSmith evals.
+
+First, help me get set up:
+1. Install dependencies: pip install langsmith langchain-openai langgraph
+2. Make sure these env vars are set: LANGSMITH_API_KEY, LANGSMITH_TRACING=true, OPENAI_API_KEY
+3. Verify the agent works: python agent.py "What is 2+2?"
+4. Run a baseline eval: python run_eval.py
+
+If I want to customize this for my own agent, walk me through:
+- Replacing agent.py with my own agent implementation
+- Replacing dataset.json with my own test cases
+- Updating the evaluators in run_eval.py for my use case
+
+Once everything is set up and the baseline looks good, read program.md and start
+the autonomous experiment loop. Do not stop to ask me questions — keep experimenting
+until I interrupt you.
+```
+
+</details>
 
 ## Bring Your Own Everything
 

--- a/examples/autoresearch/README.md
+++ b/examples/autoresearch/README.md
@@ -1,0 +1,118 @@
+# Autoresearch for Agents
+
+> Inspired by [karpathy/autoresearch](https://github.com/karpathy/autoresearch) — but instead of optimizing ML training code, we optimize **agents** using [LangSmith](https://smith.langchain.com/) observability and evals.
+
+## The Idea
+
+Give an AI coding agent a working agent implementation and an evaluation dataset. Let it experiment autonomously: modify the agent code, run evals, check if scores improved, keep or discard, and repeat. You wake up in the morning to a log of experiments and (hopefully) a better agent.
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  EXPERIMENT LOOP                     │
+│                                                      │
+│  1. Read agent.py + results so far                   │
+│  2. Propose a change (prompt, tools, architecture)   │
+│  3. Edit agent.py                                    │
+│  4. Run evaluation: python run_eval.py               │
+│  5. Parse scores from eval output                    │
+│  6. If improved → git commit (keep)                  │
+│     If worse   → git reset  (discard)                │
+│  7. Log result to results.tsv                        │
+│  8. Repeat forever                                   │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+### Comparison with Karpathy's autoresearch
+
+| | karpathy/autoresearch | autoresearch for agents |
+|---|---|---|
+| **What's optimized** | ML training code (`train.py`) | Agent code (`agent.py`) |
+| **Metric** | `val_bpb` (lower is better) | Eval score (higher is better) |
+| **Evaluation** | Fixed 5-min training run | LangSmith evaluation pipeline |
+| **Observability** | Training logs | LangSmith traces |
+| **What the agent edits** | Model architecture, optimizer, hyperparams | Prompts, tools, agent architecture |
+| **What's fixed** | `prepare.py` (data, eval) | `run_eval.py` (eval harness), `dataset.json` |
+
+## Project Structure
+
+```
+agent.py        — the agent implementation (THIS IS WHAT GETS OPTIMIZED)
+run_eval.py     — evaluation harness using LangSmith (do not modify)
+dataset.json    — evaluation dataset (do not modify)
+program.md      — instructions for the AI coding agent
+results.tsv     — experiment log (auto-generated)
+```
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.10+
+- A [LangSmith API key](https://smith.langchain.com/)
+- An [OpenAI API key](https://platform.openai.com/) (or Anthropic, etc.)
+
+### Setup
+
+```bash
+# 1. Install dependencies
+pip install langsmith langchain langchain-openai langgraph
+
+# 2. Set environment variables
+export LANGSMITH_API_KEY=<your-key>
+export LANGSMITH_TRACING=true
+export OPENAI_API_KEY=<your-key>
+
+# 3. Verify the baseline agent works
+python agent.py "What is the capital of France?"
+
+# 4. Run a single evaluation
+python run_eval.py
+```
+
+### Running the Autonomous Agent
+
+Point your coding agent (Claude Code, Cursor, Codex, etc.) at this directory and prompt:
+
+```
+Read program.md and let's kick off a new experiment! Do the setup first.
+```
+
+The coding agent will then autonomously iterate on `agent.py`, running evals and tracking results.
+
+## How It Works
+
+### The Agent (`agent.py`)
+
+A simple ReAct agent built with LangGraph. It has:
+- A system prompt (tune this!)
+- A set of tools (add/remove/modify these!)
+- An agent architecture (change this!)
+
+Everything in `agent.py` is fair game for the coding agent to modify.
+
+### The Evaluation (`run_eval.py`)
+
+Uses LangSmith's `evaluate()` to run the agent against a fixed dataset and score it with multiple evaluators:
+- **Correctness**: Does the answer match the expected output?
+- **Helpfulness**: Is the response helpful and well-structured?
+- **Tool Usage**: Did the agent use tools appropriately?
+
+All traces are sent to LangSmith for full observability.
+
+### The Dataset (`dataset.json`)
+
+A fixed set of test cases with inputs and expected outputs. The coding agent cannot modify this — it's the ground truth.
+
+## Customization
+
+This example uses a simple Q&A agent with a web search tool. To adapt it for your own agent:
+
+1. **Replace `agent.py`** with your agent implementation
+2. **Replace `dataset.json`** with your evaluation cases
+3. **Update evaluators in `run_eval.py`** to match your quality criteria
+4. **Update `program.md`** to guide the coding agent on what to optimize
+
+## License
+
+MIT

--- a/examples/autoresearch/README.md
+++ b/examples/autoresearch/README.md
@@ -38,12 +38,14 @@ Give an AI coding agent a working agent implementation and an evaluation dataset
 ## Project Structure
 
 ```
-agent.py        — the agent implementation (THIS IS WHAT GETS OPTIMIZED)
-run_eval.py     — evaluation harness using LangSmith (do not modify)
-dataset.json    — evaluation dataset (do not modify)
-program.md      — instructions for the AI coding agent
+agent.py        — YOUR agent implementation (the coding agent optimizes this)
+run_eval.py     — YOUR evaluation harness + metrics (customize before starting)
+dataset.json    — YOUR evaluation dataset (customize before starting)
+program.md      — instructions for the AI coding agent (customize before starting)
 results.tsv     — experiment log (auto-generated)
 ```
+
+**Before you start the autonomous loop**, you customize everything to fit your use case. Once the loop begins, `run_eval.py` and `dataset.json` are fixed — only `agent.py` changes.
 
 ## Quick Start
 
@@ -51,13 +53,13 @@ results.tsv     — experiment log (auto-generated)
 
 - Python 3.10+
 - A [LangSmith API key](https://smith.langchain.com/)
-- An [OpenAI API key](https://platform.openai.com/) (or Anthropic, etc.)
+- An LLM API key (OpenAI, Anthropic, etc.)
 
 ### Setup
 
 ```bash
-# 1. Install dependencies
-pip install langsmith langchain langchain-openai langgraph
+# 1. Install dependencies (adjust for your agent's needs)
+pip install langsmith langchain-openai langgraph
 
 # 2. Set environment variables
 export LANGSMITH_API_KEY=<your-key>
@@ -81,38 +83,124 @@ Read program.md and let's kick off a new experiment! Do the setup first.
 
 The coding agent will then autonomously iterate on `agent.py`, running evals and tracking results.
 
+## Bring Your Own Everything
+
+This repo ships with a working example (a Q&A agent with calculator tools), but it's designed as a **template**. Customize all three components before starting the autonomous loop.
+
+### Bring Your Own Agent
+
+Replace `agent.py` with any agent implementation. It doesn't need to use LangChain or LangGraph — any Python code works. The only requirement is that it exposes a function that `run_eval.py` can call.
+
+**Examples:**
+
+```python
+# Option A: Plain OpenAI SDK
+from openai import OpenAI
+client = OpenAI()
+
+def run_agent(question: str) -> dict:
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": question}]
+    )
+    return {"response": response.choices[0].message.content}
+```
+
+```python
+# Option B: Anthropic SDK
+import anthropic
+client = anthropic.Anthropic()
+
+def run_agent(question: str) -> dict:
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": question}]
+    )
+    return {"response": message.content[0].text}
+```
+
+```python
+# Option C: LangGraph agent (the default example)
+from langgraph.prebuilt import create_react_agent
+# ... see agent.py
+```
+
+```python
+# Option D: Custom agent with no framework
+def run_agent(question: str) -> dict:
+    # Your custom logic here — RAG, multi-step, tool use, whatever
+    return {"response": answer, "tools_used": [...]}
+```
+
+The key contract: your agent function takes the inputs from your dataset and returns a dict that your evaluators can score.
+
+### Bring Your Own Dataset
+
+Replace `dataset.json` with your evaluation cases. The format is a JSON array of objects with `inputs` and `outputs`:
+
+```json
+[
+  {
+    "inputs": {"question": "Your input here"},
+    "outputs": {"answer": "Expected output", "any_other_field": "..."}
+  }
+]
+```
+
+The field names are up to you — just make sure your evaluators in `run_eval.py` reference the same fields. Some ideas:
+
+- **Q&A agent**: `inputs: {question}`, `outputs: {answer}`
+- **RAG agent**: `inputs: {question}`, `outputs: {answer, source_docs}`
+- **Code agent**: `inputs: {task}`, `outputs: {code, test_result}`
+- **Customer support**: `inputs: {ticket}`, `outputs: {response, category, priority}`
+
+### Bring Your Own Evaluators
+
+Modify the evaluators in `run_eval.py` to match your quality criteria. Each evaluator is a function that takes `(run, example)` and returns `{"score": number, "comment": "..."}`.
+
+```python
+# LLM-as-judge evaluator
+def my_evaluator(run, example) -> dict:
+    run_outputs = run.outputs or {}
+    example_outputs = example.outputs or {}
+    # Compare run_outputs to example_outputs using an LLM judge
+    grade = judge.invoke([...])
+    return {"score": grade.score, "comment": grade.reasoning}
+
+# Code-based evaluator
+def exact_match(run, example) -> dict:
+    actual = run.outputs.get("answer", "")
+    expected = example.outputs.get("answer", "")
+    return {"score": 1 if actual == expected else 0, "comment": ""}
+```
+
+After modifying evaluators, update `program.md` to reflect the new metric names in the output format and TSV columns.
+
+### Update program.md
+
+After customizing the above, update `program.md` to match:
+- Update the file list in the Setup section
+- Update the "Ideas to try" section with domain-specific suggestions
+- Update the output format section if your metrics changed
+- Update the TSV columns to match your evaluator names
+
 ## How It Works
-
-### The Agent (`agent.py`)
-
-A simple ReAct agent built with LangGraph. It has:
-- A system prompt (tune this!)
-- A set of tools (add/remove/modify these!)
-- An agent architecture (change this!)
-
-Everything in `agent.py` is fair game for the coding agent to modify.
 
 ### The Evaluation (`run_eval.py`)
 
-Uses LangSmith's `evaluate()` to run the agent against a fixed dataset and score it with multiple evaluators:
-- **Correctness**: Does the answer match the expected output?
-- **Helpfulness**: Is the response helpful and well-structured?
-- **Tool Usage**: Did the agent use tools appropriately?
+Uses LangSmith's `evaluate()` to run the agent against a persistent dataset and score it with your evaluators. The dataset is created once in LangSmith and reused across all experiments, so results accumulate and you can compare experiments side by side in the LangSmith UI.
 
-All traces are sent to LangSmith for full observability.
+All agent runs are traced in LangSmith for full observability — you can inspect exactly what happened in each run.
 
-### The Dataset (`dataset.json`)
+### The Experiment Loop (`program.md`)
 
-A fixed set of test cases with inputs and expected outputs. The coding agent cannot modify this — it's the ground truth.
-
-## Customization
-
-This example uses a simple Q&A agent with a web search tool. To adapt it for your own agent:
-
-1. **Replace `agent.py`** with your agent implementation
-2. **Replace `dataset.json`** with your evaluation cases
-3. **Update evaluators in `run_eval.py`** to match your quality criteria
-4. **Update `program.md`** to guide the coding agent on what to optimize
+The `program.md` file is the "skill" that drives the autonomous coding agent. It tells the agent to:
+1. Edit `agent.py` with an experimental idea
+2. Commit, run eval, check scores
+3. Keep improvements, discard regressions
+4. Log everything to `results.tsv`
+5. Never stop until interrupted
 
 ## License
 

--- a/examples/autoresearch/agent.py
+++ b/examples/autoresearch/agent.py
@@ -1,8 +1,9 @@
 """
 Autoresearch agent — the file the coding agent optimizes.
 
-This is a ReAct agent built with LangGraph. Everything here is fair game:
-system prompt, tools, model, architecture, parameters.
+This is a starting template using LangGraph. You can replace this entirely
+with any agent implementation (plain OpenAI SDK, Anthropic, custom code, etc.)
+as long as you preserve the function contract expected by run_eval.py.
 
 Usage:
     python agent.py "What is 25 * 37?"
@@ -93,8 +94,17 @@ def build_agent():
     return create_react_agent(llm, tools=TOOLS, prompt=SYSTEM_PROMPT)
 
 
+# ---------------------------------------------------------------------------
+# Functions called by run_eval.py
+#
+# run_agent_with_tools() is the contract with the eval harness. It must
+# return a dict that the evaluators can score. If you replace the agent
+# entirely, just make sure this function still returns the right shape.
+# ---------------------------------------------------------------------------
+
+
 def run_agent(question: str) -> str:
-    """Run the agent on a single question and return the response."""
+    """Run the agent on a single question and return the response text."""
     return run_agent_with_tools(question)["response"]
 
 

--- a/examples/autoresearch/agent.py
+++ b/examples/autoresearch/agent.py
@@ -1,0 +1,113 @@
+"""
+Autoresearch agent — the file the coding agent optimizes.
+
+This is a ReAct agent built with LangGraph. Everything here is fair game:
+system prompt, tools, model, architecture, parameters.
+
+Usage:
+    python agent.py "What is 25 * 37?"
+"""
+
+import math
+import sys
+
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+# ---------------------------------------------------------------------------
+# Tools (add, remove, or modify these)
+# ---------------------------------------------------------------------------
+
+
+def calculator(expression: str) -> str:
+    """Evaluate a mathematical expression. Supports basic arithmetic, powers, roots, and common math functions."""
+    allowed_names = {
+        "abs": abs,
+        "round": round,
+        "min": min,
+        "max": max,
+        "pow": pow,
+        "sqrt": math.sqrt,
+        "pi": math.pi,
+        "e": math.e,
+        "log": math.log,
+        "log10": math.log10,
+        "sin": math.sin,
+        "cos": math.cos,
+        "tan": math.tan,
+    }
+    try:
+        result = eval(expression, {"__builtins__": {}}, allowed_names)
+        return str(result)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def unit_converter(value: float, from_unit: str, to_unit: str) -> str:
+    """Convert between common units. Supports temperature (C/F/K), distance (km/mi/m/ft), and weight (kg/lb)."""
+    conversions = {
+        ("km", "mi"): lambda v: v * 0.621371,
+        ("mi", "km"): lambda v: v * 1.60934,
+        ("m", "ft"): lambda v: v * 3.28084,
+        ("ft", "m"): lambda v: v * 0.3048,
+        ("kg", "lb"): lambda v: v * 2.20462,
+        ("lb", "kg"): lambda v: v * 0.453592,
+        ("c", "f"): lambda v: v * 9 / 5 + 32,
+        ("f", "c"): lambda v: (v - 32) * 5 / 9,
+        ("c", "k"): lambda v: v + 273.15,
+        ("k", "c"): lambda v: v - 273.15,
+        ("f", "k"): lambda v: (v - 32) * 5 / 9 + 273.15,
+        ("k", "f"): lambda v: (v - 273.15) * 9 / 5 + 32,
+    }
+    key = (from_unit.lower(), to_unit.lower())
+    if key in conversions:
+        result = conversions[key](value)
+        return f"{value} {from_unit} = {result:.2f} {to_unit}"
+    return f"Error: Cannot convert from {from_unit} to {to_unit}"
+
+
+# ---------------------------------------------------------------------------
+# Agent configuration
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """You are a helpful assistant. Answer questions accurately and concisely.
+
+When a question involves math, calculations, or unit conversions, use the
+appropriate tool rather than computing in your head.
+
+Always provide a direct answer to the question asked."""
+
+MODEL = "gpt-4o-mini"
+TEMPERATURE = 0
+
+TOOLS = [calculator, unit_converter]
+
+# ---------------------------------------------------------------------------
+# Build the agent
+# ---------------------------------------------------------------------------
+
+
+def build_agent():
+    """Build and return the agent graph."""
+    llm = ChatOpenAI(model=MODEL, temperature=TEMPERATURE)
+    return create_react_agent(llm, tools=TOOLS, prompt=SYSTEM_PROMPT)
+
+
+def run_agent(question: str) -> str:
+    """Run the agent on a single question and return the response."""
+    agent = build_agent()
+    result = agent.invoke({"messages": [{"role": "user", "content": question}]})
+    messages = result["messages"]
+    return messages[-1].content
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python agent.py <question>")
+        sys.exit(1)
+    question = " ".join(sys.argv[1:])
+    print(run_agent(question))

--- a/examples/autoresearch/agent.py
+++ b/examples/autoresearch/agent.py
@@ -95,10 +95,25 @@ def build_agent():
 
 def run_agent(question: str) -> str:
     """Run the agent on a single question and return the response."""
+    return run_agent_with_tools(question)["response"]
+
+
+def run_agent_with_tools(question: str) -> dict:
+    """Run the agent and return response + tool usage info for evaluation."""
     agent = build_agent()
     result = agent.invoke({"messages": [{"role": "user", "content": question}]})
     messages = result["messages"]
-    return messages[-1].content
+
+    tools_used = []
+    for msg in messages:
+        if hasattr(msg, "tool_calls") and msg.tool_calls:
+            for tc in msg.tool_calls:
+                tools_used.append(tc["name"])
+
+    return {
+        "response": messages[-1].content,
+        "tools_used": tools_used,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/examples/autoresearch/dataset.json
+++ b/examples/autoresearch/dataset.json
@@ -1,0 +1,182 @@
+[
+  {
+    "inputs": {
+      "question": "What is the capital of France?"
+    },
+    "outputs": {
+      "answer": "The capital of France is Paris.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is 25 * 37 + 14?"
+    },
+    "outputs": {
+      "answer": "939",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "Convert 72 degrees Fahrenheit to Celsius."
+    },
+    "outputs": {
+      "answer": "22.22 degrees Celsius",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "Who wrote the novel '1984'?"
+    },
+    "outputs": {
+      "answer": "George Orwell wrote the novel '1984'.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is the square root of 144?"
+    },
+    "outputs": {
+      "answer": "12",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "Summarize the theory of relativity in one sentence."
+    },
+    "outputs": {
+      "answer": "Einstein's theory of relativity describes how space and time are interwoven and how gravity arises from the curvature of spacetime caused by mass and energy.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is the chemical formula for water?"
+    },
+    "outputs": {
+      "answer": "H2O",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "If a train travels at 60 mph for 2.5 hours, how far does it go?"
+    },
+    "outputs": {
+      "answer": "150 miles",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "What are the three states of matter?"
+    },
+    "outputs": {
+      "answer": "The three states of matter are solid, liquid, and gas.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "Calculate the area of a circle with radius 7."
+    },
+    "outputs": {
+      "answer": "Approximately 153.94 square units",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is the largest planet in our solar system?"
+    },
+    "outputs": {
+      "answer": "Jupiter is the largest planet in our solar system.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is 15% of 200?"
+    },
+    "outputs": {
+      "answer": "30",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "Explain what photosynthesis is in simple terms."
+    },
+    "outputs": {
+      "answer": "Photosynthesis is the process by which plants use sunlight, water, and carbon dioxide to produce oxygen and glucose for energy.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is the boiling point of water in Kelvin?"
+    },
+    "outputs": {
+      "answer": "373.15 Kelvin",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "Who painted the Mona Lisa?"
+    },
+    "outputs": {
+      "answer": "Leonardo da Vinci painted the Mona Lisa.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "What is the derivative of x^3 + 2x?"
+    },
+    "outputs": {
+      "answer": "3x^2 + 2",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "Name the four oceans of the world."
+    },
+    "outputs": {
+      "answer": "The four main oceans are the Pacific, Atlantic, Indian, and Arctic oceans.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "If you have 3 apples and buy 5 more, then give away 2, how many do you have?"
+    },
+    "outputs": {
+      "answer": "6 apples",
+      "expected_tool_use": true
+    }
+  },
+  {
+    "inputs": {
+      "question": "What does DNA stand for?"
+    },
+    "outputs": {
+      "answer": "DNA stands for deoxyribonucleic acid.",
+      "expected_tool_use": false
+    }
+  },
+  {
+    "inputs": {
+      "question": "Convert 5 kilometers to miles."
+    },
+    "outputs": {
+      "answer": "Approximately 3.11 miles",
+      "expected_tool_use": true
+    }
+  }
+]

--- a/examples/autoresearch/program.md
+++ b/examples/autoresearch/program.md
@@ -40,7 +40,7 @@ Each experiment runs the agent against a fixed evaluation dataset using LangSmit
 
 **Cost** is a soft constraint. Using a more expensive model (e.g. gpt-4o instead of gpt-4o-mini) is acceptable for meaningful score gains, but don't use unnecessarily expensive configurations for marginal improvements.
 
-**Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win.
+**Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude. A 0.01 overall_score improvement that adds 30 lines of hacky prompt engineering? Probably not worth it. A 0.01 improvement from simplifying the prompt? Definitely keep. An improvement of ~0 but much simpler code? Keep.
 
 ## Output format
 
@@ -67,7 +67,7 @@ grep "^overall_score:" eval.log
 
 When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated).
 
-The TSV has a header row and 6 columns:
+The TSV has a header row and 7 columns:
 
 ```
 commit	overall_score	correctness	helpfulness	tool_usage	status	description
@@ -106,20 +106,24 @@ LOOP FOREVER:
    - Combining previous near-misses
 3. Edit `agent.py` with your experimental idea
 4. git commit
-5. Run the experiment: `python run_eval.py > eval.log 2>&1` (redirect everything — do NOT let output flood your context)
+5. Run the experiment: `python run_eval.py > eval.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
 6. Read out the results: `grep "^overall_score:\|^avg_" eval.log`
-7. If the grep output is empty, the run crashed. Run `tail -n 50 eval.log` to read the error and attempt a fix.
+7. If the grep output is empty, the run crashed. Run `tail -n 50 eval.log` to read the error and attempt a fix. If you can't get things to work after more than a few attempts, give up.
 8. Record the results in the TSV
 9. If overall_score improved (higher), you "advance" the branch, keeping the git commit
 10. If overall_score is equal or worse, you git reset back to where you started
 
-The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate.
+The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind further back but you should probably do this very very sparingly (if ever).
+
+**Timeout**: Each experiment should take ~2-5 minutes depending on API latency. If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
 
 **Crashes**: If a run crashes, use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the TSV, and move on.
 
 **NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — re-read the agent code, look at which eval cases are failing, try combining previous near-misses, try more radical changes. The loop runs until the human interrupts you, period.
 
 **LangSmith observability**: Every experiment run sends traces to LangSmith. After each run, you can check the experiment URL in the output to see detailed traces of how the agent handled each test case. Use this information to guide your next experiment — look at which cases the agent got wrong and why.
+
+As an example use case, a user might leave you running while they sleep. If each experiment takes you ~3 minutes then you can run approx 20/hour, for a total of about 160 over the duration of the average human sleep. The user then wakes up to experimental results, all completed by you while they slept!
 
 ## Ideas to try
 

--- a/examples/autoresearch/program.md
+++ b/examples/autoresearch/program.md
@@ -9,14 +9,14 @@ To set up a new experiment, work with the user to:
 1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `autoresearch/<tag>` must not already exist — this is a fresh run.
 2. **Create the branch**: `git checkout -b autoresearch/<tag>` from current main.
 3. **Read the in-scope files**: The project is small. Read these files for full context:
-   - `README.md` — project context.
-   - `agent.py` — the file you modify. Agent implementation: prompt, tools, model, architecture.
-   - `run_eval.py` — fixed evaluation harness. Do not modify.
-   - `dataset.json` — fixed evaluation dataset. Do not modify.
+   - `README.md` — project context and customization guide.
+   - `agent.py` — the file you modify. The agent implementation.
+   - `run_eval.py` — evaluation harness and metrics. Fixed during the experiment loop.
+   - `dataset.json` — evaluation dataset. Fixed during the experiment loop.
 4. **Verify setup**: Check that required environment variables are set:
    - `LANGSMITH_API_KEY`
    - `LANGSMITH_TRACING=true`
-   - `OPENAI_API_KEY`
+   - Any LLM API keys the agent needs (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
 5. **Run the baseline**: Your first run establishes the baseline. Run `python run_eval.py` and record the results.
 6. **Initialize results.tsv**: Create `results.tsv` with header row and the baseline entry.
 7. **Confirm and go**: Confirm setup looks good.
@@ -28,15 +28,15 @@ Once you get confirmation, kick off the experimentation.
 Each experiment runs the agent against a fixed evaluation dataset using LangSmith. You launch it simply as: `python run_eval.py > eval.log 2>&1`.
 
 **What you CAN do:**
-- Modify `agent.py` — this is the only file you edit. Everything is fair game: system prompt, tools, model choice, temperature, agent architecture, tool descriptions, output formatting, etc.
+- Modify `agent.py` — this is the only file you edit. Everything is fair game: system prompt, tools, model choice, temperature, agent architecture, framework, output formatting, etc. You can even replace the entire implementation (e.g. switch from LangGraph to plain OpenAI SDK) as long as the function contract expected by `run_eval.py` is preserved.
 
 **What you CANNOT do:**
-- Modify `run_eval.py`. It is read-only. It contains the fixed evaluation harness and evaluators.
-- Modify `dataset.json`. It is read-only. It contains the fixed test cases.
+- Modify `run_eval.py`. It is read-only during the experiment loop. It contains the evaluation harness and metrics.
+- Modify `dataset.json`. It is read-only during the experiment loop. It contains the test cases.
 - Install new packages or add dependencies beyond what's already available.
 - Modify the evaluators. The scoring functions in `run_eval.py` are the ground truth metrics.
 
-**The goal is simple: get the highest `overall_score`.** Since the evaluation is fixed, you don't need to worry about the eval pipeline — it's always the same. Everything in `agent.py` is fair game: change the prompt, the tools, the model, the temperature, the architecture. The only constraint is that the code runs without crashing and the agent returns valid responses.
+**The goal is simple: get the highest `overall_score`.** Since the evaluation is fixed, you don't need to worry about the eval pipeline — it's always the same. Everything in `agent.py` is fair game. The only constraint is that the code runs without crashing and the agent returns valid responses matching the contract expected by `run_eval.py`.
 
 **Cost** is a soft constraint. Using a more expensive model (e.g. gpt-4o instead of gpt-4o-mini) is acceptable for meaningful score gains, but don't use unnecessarily expensive configurations for marginal improvements.
 
@@ -101,8 +101,8 @@ LOOP FOREVER:
 2. Think about what to try next. Consider:
    - Improving the system prompt (more specific instructions, better formatting guidance)
    - Adding or improving tools (better descriptions, more capable implementations)
-   - Changing the model (gpt-4o vs gpt-4o-mini, temperature adjustments)
-   - Modifying the agent architecture (different agent types, custom logic)
+   - Changing the model or provider (gpt-4o vs gpt-4o-mini, Claude vs GPT, temperature adjustments)
+   - Modifying the agent architecture (different agent types, custom logic, different framework)
    - Combining previous near-misses
 3. Edit `agent.py` with your experimental idea
 4. git commit
@@ -131,9 +131,10 @@ Here are some starting ideas (but don't limit yourself to these):
 
 - **Prompt engineering**: Add explicit instructions for when to use tools vs. answer directly
 - **Tool descriptions**: Make tool docstrings more descriptive so the LLM knows when to use them
-- **Few-shot examples**: Add examples to the system prompt showing correct tool usage
-- **Model upgrade**: Try gpt-4o instead of gpt-4o-mini for better reasoning
+- **Few-shot examples**: Add examples to the system prompt showing correct behavior
+- **Model upgrade**: Try a more capable model for better reasoning
 - **Temperature tuning**: Try temperature=0.1 or 0.2 for slightly more creative responses
 - **Output formatting**: Add instructions about response format (concise, direct answers)
 - **Tool improvements**: Make tools more robust, handle edge cases better
-- **Architecture changes**: Try a different agent pattern or add custom routing logic
+- **Architecture changes**: Try a different agent pattern, framework, or custom routing logic
+- **Framework swap**: Try replacing the agent framework entirely (e.g. LangGraph → plain SDK)

--- a/examples/autoresearch/program.md
+++ b/examples/autoresearch/program.md
@@ -1,0 +1,135 @@
+# autoresearch for agents
+
+This is an experiment to have an LLM autonomously improve an agent through iterative experimentation, evaluated with LangSmith.
+
+## Setup
+
+To set up a new experiment, work with the user to:
+
+1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar5`). The branch `autoresearch/<tag>` must not already exist — this is a fresh run.
+2. **Create the branch**: `git checkout -b autoresearch/<tag>` from current main.
+3. **Read the in-scope files**: The project is small. Read these files for full context:
+   - `README.md` — project context.
+   - `agent.py` — the file you modify. Agent implementation: prompt, tools, model, architecture.
+   - `run_eval.py` — fixed evaluation harness. Do not modify.
+   - `dataset.json` — fixed evaluation dataset. Do not modify.
+4. **Verify setup**: Check that required environment variables are set:
+   - `LANGSMITH_API_KEY`
+   - `LANGSMITH_TRACING=true`
+   - `OPENAI_API_KEY`
+5. **Run the baseline**: Your first run establishes the baseline. Run `python run_eval.py` and record the results.
+6. **Initialize results.tsv**: Create `results.tsv` with header row and the baseline entry.
+7. **Confirm and go**: Confirm setup looks good.
+
+Once you get confirmation, kick off the experimentation.
+
+## Experimentation
+
+Each experiment runs the agent against a fixed evaluation dataset using LangSmith. You launch it simply as: `python run_eval.py > eval.log 2>&1`.
+
+**What you CAN do:**
+- Modify `agent.py` — this is the only file you edit. Everything is fair game: system prompt, tools, model choice, temperature, agent architecture, tool descriptions, output formatting, etc.
+
+**What you CANNOT do:**
+- Modify `run_eval.py`. It is read-only. It contains the fixed evaluation harness and evaluators.
+- Modify `dataset.json`. It is read-only. It contains the fixed test cases.
+- Install new packages or add dependencies beyond what's already available.
+- Modify the evaluators. The scoring functions in `run_eval.py` are the ground truth metrics.
+
+**The goal is simple: get the highest `overall_score`.** Since the evaluation is fixed, you don't need to worry about the eval pipeline — it's always the same. Everything in `agent.py` is fair game: change the prompt, the tools, the model, the temperature, the architecture. The only constraint is that the code runs without crashing and the agent returns valid responses.
+
+**Cost** is a soft constraint. Using a more expensive model (e.g. gpt-4o instead of gpt-4o-mini) is acceptable for meaningful score gains, but don't use unnecessarily expensive configurations for marginal improvements.
+
+**Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win.
+
+## Output format
+
+Once the evaluation finishes it prints a summary like this:
+
+```
+---
+avg_correctness: 0.850000
+avg_helpfulness: 0.900000
+avg_tool_usage: 0.750000
+overall_score: 0.833333
+num_examples: 20
+num_errors: 0
+experiment_url: https://smith.langchain.com/...
+```
+
+You can extract the key metric from the log file:
+
+```
+grep "^overall_score:" eval.log
+```
+
+## Logging results
+
+When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated).
+
+The TSV has a header row and 6 columns:
+
+```
+commit	overall_score	correctness	helpfulness	tool_usage	status	description
+```
+
+1. git commit hash (short, 7 chars)
+2. overall_score achieved (e.g. 0.833333) — use 0.000000 for crashes
+3. correctness score
+4. helpfulness score
+5. tool_usage score
+6. status: `keep`, `discard`, or `crash`
+7. short text description of what this experiment tried
+
+Example:
+
+```
+commit	overall_score	correctness	helpfulness	tool_usage	status	description
+a1b2c3d	0.833333	0.850000	0.900000	0.750000	keep	baseline
+b2c3d4e	0.866667	0.900000	0.900000	0.800000	keep	improved system prompt with explicit tool instructions
+c3d4e5f	0.800000	0.800000	0.850000	0.750000	discard	switched to gpt-3.5-turbo
+d4e5f6g	0.000000	0.000000	0.000000	0.000000	crash	added broken custom tool
+```
+
+## The experiment loop
+
+The experiment runs on a dedicated branch (e.g. `autoresearch/mar5`).
+
+LOOP FOREVER:
+
+1. Look at the git state: the current branch/commit we're on
+2. Think about what to try next. Consider:
+   - Improving the system prompt (more specific instructions, better formatting guidance)
+   - Adding or improving tools (better descriptions, more capable implementations)
+   - Changing the model (gpt-4o vs gpt-4o-mini, temperature adjustments)
+   - Modifying the agent architecture (different agent types, custom logic)
+   - Combining previous near-misses
+3. Edit `agent.py` with your experimental idea
+4. git commit
+5. Run the experiment: `python run_eval.py > eval.log 2>&1` (redirect everything — do NOT let output flood your context)
+6. Read out the results: `grep "^overall_score:\|^avg_" eval.log`
+7. If the grep output is empty, the run crashed. Run `tail -n 50 eval.log` to read the error and attempt a fix.
+8. Record the results in the TSV
+9. If overall_score improved (higher), you "advance" the branch, keeping the git commit
+10. If overall_score is equal or worse, you git reset back to where you started
+
+The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate.
+
+**Crashes**: If a run crashes, use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the TSV, and move on.
+
+**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — re-read the agent code, look at which eval cases are failing, try combining previous near-misses, try more radical changes. The loop runs until the human interrupts you, period.
+
+**LangSmith observability**: Every experiment run sends traces to LangSmith. After each run, you can check the experiment URL in the output to see detailed traces of how the agent handled each test case. Use this information to guide your next experiment — look at which cases the agent got wrong and why.
+
+## Ideas to try
+
+Here are some starting ideas (but don't limit yourself to these):
+
+- **Prompt engineering**: Add explicit instructions for when to use tools vs. answer directly
+- **Tool descriptions**: Make tool docstrings more descriptive so the LLM knows when to use them
+- **Few-shot examples**: Add examples to the system prompt showing correct tool usage
+- **Model upgrade**: Try gpt-4o instead of gpt-4o-mini for better reasoning
+- **Temperature tuning**: Try temperature=0.1 or 0.2 for slightly more creative responses
+- **Output formatting**: Add instructions about response format (concise, direct answers)
+- **Tool improvements**: Make tools more robust, handle edge cases better
+- **Architecture changes**: Try a different agent pattern or add custom routing logic

--- a/examples/autoresearch/run_eval.py
+++ b/examples/autoresearch/run_eval.py
@@ -24,10 +24,11 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from langchain_openai import ChatOpenAI
-from langsmith import Client, evaluate, traceable
+from langsmith import Client, evaluate
+from pydantic import BaseModel, Field
 
 SCRIPT_DIR = Path(__file__).parent
 
@@ -42,16 +43,15 @@ def load_dataset(path: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-@traceable(name="agent_run")
 def run_agent_for_eval(inputs: dict) -> dict:
+    """Run the agent and capture tool usage in the output for evaluators."""
     sys.path.insert(0, str(SCRIPT_DIR))
-    from agent import run_agent
+    from agent import run_agent_with_tools
 
     try:
-        response = run_agent(inputs["question"])
-        return {"response": response}
+        return run_agent_with_tools(inputs["question"])
     except Exception as e:
-        return {"response": f"ERROR: {e}", "error": True}
+        return {"response": f"ERROR: {e}", "error": True, "tools_used": []}
 
 
 # ---------------------------------------------------------------------------
@@ -59,8 +59,20 @@ def run_agent_for_eval(inputs: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _get_judge():
-    return ChatOpenAI(model="gpt-4o-mini", temperature=0)
+class CorrectnessGrade(BaseModel):
+    reasoning: Annotated[str, Field(description="Explain your reasoning")]
+    score: Annotated[int, Field(description="1 if correct, 0 if incorrect")]
+
+
+class HelpfulnessGrade(BaseModel):
+    reasoning: Annotated[str, Field(description="Explain your reasoning")]
+    score: Annotated[int, Field(description="1 if helpful, 0 if unhelpful")]
+
+
+def _get_judge(schema: type[BaseModel]) -> Any:
+    return ChatOpenAI(model="gpt-4o-mini", temperature=0).with_structured_output(
+        schema, method="json_schema", strict=True
+    )
 
 
 def correctness_evaluator(run, example) -> dict:
@@ -74,7 +86,7 @@ def correctness_evaluator(run, example) -> dict:
     if run_outputs.get("error"):
         return {"score": 0, "comment": "Agent returned an error"}
 
-    judge = _get_judge()
+    judge = _get_judge(CorrectnessGrade)
     grade = judge.invoke(
         [
             {
@@ -82,8 +94,7 @@ def correctness_evaluator(run, example) -> dict:
                 "content": (
                     "You are grading an AI assistant's response. "
                     "Score 1 if the response contains the correct answer (it doesn't need to match exactly, "
-                    "just be factually equivalent). Score 0 if incorrect or missing. "
-                    "Respond with ONLY a JSON object: {\"score\": 0 or 1, \"reasoning\": \"...\"}"
+                    "just be factually equivalent). Score 0 if incorrect or missing."
                 ),
             },
             {
@@ -92,24 +103,21 @@ def correctness_evaluator(run, example) -> dict:
             },
         ]
     )
-    try:
-        result = json.loads(grade.content)
-        return {"score": result.get("score", 0), "comment": result.get("reasoning", "")}
-    except (json.JSONDecodeError, AttributeError):
-        content = grade.content if hasattr(grade, "content") else str(grade)
-        return {"score": 0, "comment": f"Judge parse error: {content}"}
+    return {"score": grade.score, "comment": grade.reasoning}
 
 
 def helpfulness_evaluator(run, example) -> dict:
     """Score whether the response is helpful, clear, and well-structured."""
     run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
+    example_inputs = example.inputs if hasattr(example, "inputs") else example.get("inputs", {}) or {}
 
     response = run_outputs.get("response", "")
+    question = example_inputs.get("question", "")
 
     if run_outputs.get("error"):
         return {"score": 0, "comment": "Agent returned an error"}
 
-    judge = _get_judge()
+    judge = _get_judge(HelpfulnessGrade)
     grade = judge.invoke(
         [
             {
@@ -117,26 +125,20 @@ def helpfulness_evaluator(run, example) -> dict:
                 "content": (
                     "You are grading an AI assistant's response for helpfulness. "
                     "Score 1 if the response is clear, direct, and helpful. "
-                    "Score 0 if it's confusing, overly verbose, or unhelpful. "
-                    "Respond with ONLY a JSON object: {\"score\": 0 or 1, \"reasoning\": \"...\"}"
+                    "Score 0 if it's confusing, overly verbose, or unhelpful."
                 ),
             },
             {
                 "role": "user",
-                "content": f"Question: {example.inputs.get('question', '') if hasattr(example, 'inputs') else example.get('inputs', {}).get('question', '')}\n\nResponse: {response}",
+                "content": f"Question: {question}\n\nResponse: {response}",
             },
         ]
     )
-    try:
-        result = json.loads(grade.content)
-        return {"score": result.get("score", 0), "comment": result.get("reasoning", "")}
-    except (json.JSONDecodeError, AttributeError):
-        content = grade.content if hasattr(grade, "content") else str(grade)
-        return {"score": 0, "comment": f"Judge parse error: {content}"}
+    return {"score": grade.score, "comment": grade.reasoning}
 
 
 def tool_usage_evaluator(run, example) -> dict:
-    """Score whether the agent used tools appropriately (used them when expected, didn't when not)."""
+    """Score whether the agent used tools appropriately."""
     run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
     example_outputs = example.outputs if hasattr(example, "outputs") else example.get("outputs", {}) or {}
 
@@ -147,17 +149,14 @@ def tool_usage_evaluator(run, example) -> dict:
     if expected_tool_use is None:
         return {"score": 1, "comment": "No tool usage expectation defined"}
 
-    response = run_outputs.get("response", "")
-    used_tool = "Error:" not in response and any(
-        marker in str(run_outputs)
-        for marker in ["calculator", "unit_converter", "tool_calls"]
-    )
+    tools_used = run_outputs.get("tools_used", [])
+    actually_used = len(tools_used) > 0
 
-    if expected_tool_use and not used_tool:
+    if expected_tool_use and not actually_used:
         return {"score": 0, "comment": "Expected tool use but agent didn't use tools"}
-    if not expected_tool_use and used_tool:
-        return {"score": 0, "comment": "Agent used tools when not expected"}
-    return {"score": 1, "comment": "Tool usage matched expectations"}
+    if not expected_tool_use and actually_used:
+        return {"score": 0, "comment": f"Agent used tools when not expected: {tools_used}"}
+    return {"score": 1, "comment": f"Tool usage matched expectations (tools: {tools_used})"}
 
 
 # ---------------------------------------------------------------------------
@@ -170,11 +169,8 @@ DATASET_NAME = "autoresearch-agent-eval"
 
 def get_or_create_dataset(client: Client, dataset_path: str) -> str:
     """Return the persistent dataset name, creating it from dataset.json if it doesn't exist yet."""
-    try:
-        client.read_dataset(dataset_name=DATASET_NAME)
+    if client.has_dataset(dataset_name=DATASET_NAME):
         return DATASET_NAME
-    except Exception:
-        pass
 
     examples = load_dataset(dataset_path)
     client.create_dataset(DATASET_NAME, description="Autoresearch agent evaluation dataset")
@@ -208,26 +204,20 @@ def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
 
     for result in results:
         num_examples += 1
-        eval_results = result.get("evaluation_results", {})
-        eval_list = eval_results.get("results", [])
+        eval_results = result["evaluation_results"]
+        eval_list = eval_results["results"]
 
         for er in eval_list:
-            key = er.key if hasattr(er, "key") else er.get("key", "")
-            score = er.score if hasattr(er, "score") else er.get("score", 0)
-            if score is None:
-                score = 0
-            if "correctness" in key:
-                correctness_scores.append(score)
-            elif "helpfulness" in key:
-                helpfulness_scores.append(score)
-            elif "tool_usage" in key:
-                tool_usage_scores.append(score)
+            if er.score is None:
+                continue
+            if "correctness" in er.key:
+                correctness_scores.append(er.score)
+            elif "helpfulness" in er.key:
+                helpfulness_scores.append(er.score)
+            elif "tool_usage" in er.key:
+                tool_usage_scores.append(er.score)
 
-        run_output = result.get("run", {})
-        if hasattr(run_output, "outputs"):
-            outputs = run_output.outputs or {}
-        else:
-            outputs = run_output.get("outputs", {}) or {}
+        outputs = result["run"].outputs or {}
         if outputs.get("error"):
             num_errors += 1
 
@@ -238,10 +228,9 @@ def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
 
     experiment_url = ""
     try:
-        ds = client.read_dataset(dataset_name=dataset_name)
-        experiments = list(client.list_experiments(dataset_id=ds.id))
-        if experiments:
-            experiment_url = experiments[0].url or ""
+        projects = list(client.list_projects(name=results.experiment_name))
+        if projects:
+            experiment_url = projects[0].url or ""
     except Exception:
         pass
 

--- a/examples/autoresearch/run_eval.py
+++ b/examples/autoresearch/run_eval.py
@@ -23,7 +23,6 @@ Output format (parsed by the experiment loop):
 import argparse
 import json
 import sys
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -166,18 +165,32 @@ def tool_usage_evaluator(run, example) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
-    client = Client()
+DATASET_NAME = "autoresearch-agent-eval"
+
+
+def get_or_create_dataset(client: Client, dataset_path: str) -> str:
+    """Return the persistent dataset name, creating it from dataset.json if it doesn't exist yet."""
+    try:
+        client.read_dataset(dataset_name=DATASET_NAME)
+        return DATASET_NAME
+    except Exception:
+        pass
 
     examples = load_dataset(dataset_path)
-
-    dataset_name = f"autoresearch-eval-{uuid.uuid4().hex[:8]}"
-    dataset = client.create_dataset(dataset_name, description="Autoresearch evaluation dataset")
+    client.create_dataset(DATASET_NAME, description="Autoresearch agent evaluation dataset")
     client.create_examples(
         inputs=[e["inputs"] for e in examples],
         outputs=[e["outputs"] for e in examples],
-        dataset_name=dataset_name,
+        dataset_name=DATASET_NAME,
     )
+    print(f"Created persistent dataset: {DATASET_NAME}")
+    return DATASET_NAME
+
+
+def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
+    client = Client()
+
+    dataset_name = get_or_create_dataset(client, dataset_path)
 
     results = evaluate(
         run_agent_for_eval,
@@ -191,8 +204,10 @@ def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
     helpfulness_scores = []
     tool_usage_scores = []
     num_errors = 0
+    num_examples = 0
 
     for result in results:
+        num_examples += 1
         eval_results = result.get("evaluation_results", {})
         eval_list = eval_results.get("results", [])
 
@@ -230,22 +245,15 @@ def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
     except Exception:
         pass
 
-    summary = {
+    return {
         "avg_correctness": avg_correctness,
         "avg_helpfulness": avg_helpfulness,
         "avg_tool_usage": avg_tool_usage,
         "overall_score": overall,
-        "num_examples": len(examples),
+        "num_examples": num_examples,
         "num_errors": num_errors,
         "experiment_url": experiment_url,
     }
-
-    try:
-        client.delete_dataset(dataset_name=dataset_name)
-    except Exception:
-        pass
-
-    return summary
 
 
 def main():

--- a/examples/autoresearch/run_eval.py
+++ b/examples/autoresearch/run_eval.py
@@ -1,9 +1,9 @@
 """
 Evaluation harness for autoresearch agents.
 
-Runs the agent against a fixed dataset and scores it using LangSmith.
-DO NOT MODIFY — this is the fixed evaluation, equivalent to prepare.py
-in karpathy/autoresearch.
+Runs the agent against a dataset and scores it using LangSmith.
+Customize this file BEFORE starting the autonomous experiment loop.
+Once the loop begins, this file is fixed — only agent.py changes.
 
 Usage:
     python run_eval.py
@@ -18,6 +18,12 @@ Output format (parsed by the experiment loop):
     num_examples: 20
     num_errors: 0
     experiment_url: https://smith.langchain.com/...
+
+Customization points (search for "CUSTOMIZE"):
+    1. run_agent_for_eval() — how to call your agent
+    2. Evaluators — what metrics to score
+    3. EVALUATORS list — which evaluators to run
+    4. DATASET_NAME — name of the persistent LangSmith dataset
 """
 
 import argparse
@@ -39,12 +45,18 @@ def load_dataset(path: str) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Run function — wraps the agent for evaluation
+# CUSTOMIZE 1: Run function — how to call your agent
+#
+# This function is called once per dataset example. It receives the example's
+# inputs dict and must return a dict that your evaluators can score.
+#
+# The return dict is what evaluators see as `run.outputs`. If you need
+# evaluators to check tool usage, trajectories, etc., return that data here.
 # ---------------------------------------------------------------------------
 
 
 def run_agent_for_eval(inputs: dict) -> dict:
-    """Run the agent and capture tool usage in the output for evaluators."""
+    """Call the agent and return outputs for evaluators to score."""
     sys.path.insert(0, str(SCRIPT_DIR))
     from agent import run_agent_with_tools
 
@@ -55,7 +67,13 @@ def run_agent_for_eval(inputs: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Evaluators
+# CUSTOMIZE 2: Evaluators
+#
+# Each evaluator takes (run, example) and returns {"score": number, "comment": str}.
+# - run.outputs  = the dict your run function returned above
+# - example.outputs = the "outputs" from your dataset.json
+#
+# Add, remove, or replace these to match your quality criteria.
 # ---------------------------------------------------------------------------
 
 
@@ -76,9 +94,9 @@ def _get_judge(schema: type[BaseModel]) -> Any:
 
 
 def correctness_evaluator(run, example) -> dict:
-    """Score whether the agent's response is factually correct compared to the expected answer."""
-    run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
-    example_outputs = example.outputs if hasattr(example, "outputs") else example.get("outputs", {}) or {}
+    """LLM-as-judge: is the response factually correct?"""
+    run_outputs = run.outputs or {}
+    example_outputs = example.outputs or {}
 
     response = run_outputs.get("response", "")
     expected = example_outputs.get("answer", "")
@@ -107,9 +125,9 @@ def correctness_evaluator(run, example) -> dict:
 
 
 def helpfulness_evaluator(run, example) -> dict:
-    """Score whether the response is helpful, clear, and well-structured."""
-    run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
-    example_inputs = example.inputs if hasattr(example, "inputs") else example.get("inputs", {}) or {}
+    """LLM-as-judge: is the response clear, direct, and helpful?"""
+    run_outputs = run.outputs or {}
+    example_inputs = example.inputs or {}
 
     response = run_outputs.get("response", "")
     question = example_inputs.get("question", "")
@@ -138,9 +156,9 @@ def helpfulness_evaluator(run, example) -> dict:
 
 
 def tool_usage_evaluator(run, example) -> dict:
-    """Score whether the agent used tools appropriately."""
-    run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
-    example_outputs = example.outputs if hasattr(example, "outputs") else example.get("outputs", {}) or {}
+    """Code-based: did the agent use tools when expected?"""
+    run_outputs = run.outputs or {}
+    example_outputs = example.outputs or {}
 
     if run_outputs.get("error"):
         return {"score": 0, "comment": "Agent returned an error"}
@@ -160,11 +178,20 @@ def tool_usage_evaluator(run, example) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Main evaluation
+# CUSTOMIZE 3: Which evaluators to run
 # ---------------------------------------------------------------------------
 
+EVALUATORS = [correctness_evaluator, helpfulness_evaluator, tool_usage_evaluator]
+
+# ---------------------------------------------------------------------------
+# CUSTOMIZE 4: Dataset name in LangSmith (persistent across experiments)
+# ---------------------------------------------------------------------------
 
 DATASET_NAME = "autoresearch-agent-eval"
+
+# ---------------------------------------------------------------------------
+# Evaluation infrastructure (you probably don't need to change below here)
+# ---------------------------------------------------------------------------
 
 
 def get_or_create_dataset(client: Client, dataset_path: str) -> str:
@@ -191,40 +218,27 @@ def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
     results = evaluate(
         run_agent_for_eval,
         data=dataset_name,
-        evaluators=[correctness_evaluator, helpfulness_evaluator, tool_usage_evaluator],
+        evaluators=EVALUATORS,
         experiment_prefix=prefix,
         max_concurrency=4,
     )
 
-    correctness_scores = []
-    helpfulness_scores = []
-    tool_usage_scores = []
+    scores_by_evaluator: dict[str, list[float]] = {}
     num_errors = 0
     num_examples = 0
 
     for result in results:
         num_examples += 1
-        eval_results = result["evaluation_results"]
-        eval_list = eval_results["results"]
-
-        for er in eval_list:
-            if er.score is None:
-                continue
-            if "correctness" in er.key:
-                correctness_scores.append(er.score)
-            elif "helpfulness" in er.key:
-                helpfulness_scores.append(er.score)
-            elif "tool_usage" in er.key:
-                tool_usage_scores.append(er.score)
+        for er in result["evaluation_results"]["results"]:
+            if er.score is not None:
+                scores_by_evaluator.setdefault(er.key, []).append(er.score)
 
         outputs = result["run"].outputs or {}
         if outputs.get("error"):
             num_errors += 1
 
-    avg_correctness = sum(correctness_scores) / len(correctness_scores) if correctness_scores else 0
-    avg_helpfulness = sum(helpfulness_scores) / len(helpfulness_scores) if helpfulness_scores else 0
-    avg_tool_usage = sum(tool_usage_scores) / len(tool_usage_scores) if tool_usage_scores else 0
-    overall = (avg_correctness + avg_helpfulness + avg_tool_usage) / 3
+    averages = {k: sum(v) / len(v) for k, v in scores_by_evaluator.items() if v}
+    overall = sum(averages.values()) / len(averages) if averages else 0
 
     experiment_url = ""
     try:
@@ -234,15 +248,12 @@ def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
     except Exception:
         pass
 
-    return {
-        "avg_correctness": avg_correctness,
-        "avg_helpfulness": avg_helpfulness,
-        "avg_tool_usage": avg_tool_usage,
-        "overall_score": overall,
-        "num_examples": num_examples,
-        "num_errors": num_errors,
-        "experiment_url": experiment_url,
-    }
+    summary = {f"avg_{k}": v for k, v in averages.items()}
+    summary["overall_score"] = overall
+    summary["num_examples"] = num_examples
+    summary["num_errors"] = num_errors
+    summary["experiment_url"] = experiment_url
+    return summary
 
 
 def main():

--- a/examples/autoresearch/run_eval.py
+++ b/examples/autoresearch/run_eval.py
@@ -1,0 +1,268 @@
+"""
+Evaluation harness for autoresearch agents.
+
+Runs the agent against a fixed dataset and scores it using LangSmith.
+DO NOT MODIFY — this is the fixed evaluation, equivalent to prepare.py
+in karpathy/autoresearch.
+
+Usage:
+    python run_eval.py
+    python run_eval.py --dataset dataset.json --prefix "experiment-1"
+
+Output format (parsed by the experiment loop):
+    ---
+    avg_correctness: 0.850000
+    avg_helpfulness: 0.900000
+    avg_tool_usage: 0.750000
+    overall_score: 0.833333
+    num_examples: 20
+    num_errors: 0
+    experiment_url: https://smith.langchain.com/...
+"""
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+from langsmith import Client, evaluate, traceable
+
+SCRIPT_DIR = Path(__file__).parent
+
+
+def load_dataset(path: str) -> list[dict]:
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Run function — wraps the agent for evaluation
+# ---------------------------------------------------------------------------
+
+
+@traceable(name="agent_run")
+def run_agent_for_eval(inputs: dict) -> dict:
+    sys.path.insert(0, str(SCRIPT_DIR))
+    from agent import run_agent
+
+    try:
+        response = run_agent(inputs["question"])
+        return {"response": response}
+    except Exception as e:
+        return {"response": f"ERROR: {e}", "error": True}
+
+
+# ---------------------------------------------------------------------------
+# Evaluators
+# ---------------------------------------------------------------------------
+
+
+def _get_judge():
+    return ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+
+def correctness_evaluator(run, example) -> dict:
+    """Score whether the agent's response is factually correct compared to the expected answer."""
+    run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
+    example_outputs = example.outputs if hasattr(example, "outputs") else example.get("outputs", {}) or {}
+
+    response = run_outputs.get("response", "")
+    expected = example_outputs.get("answer", "")
+
+    if run_outputs.get("error"):
+        return {"score": 0, "comment": "Agent returned an error"}
+
+    judge = _get_judge()
+    grade = judge.invoke(
+        [
+            {
+                "role": "system",
+                "content": (
+                    "You are grading an AI assistant's response. "
+                    "Score 1 if the response contains the correct answer (it doesn't need to match exactly, "
+                    "just be factually equivalent). Score 0 if incorrect or missing. "
+                    "Respond with ONLY a JSON object: {\"score\": 0 or 1, \"reasoning\": \"...\"}"
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Expected answer: {expected}\n\nActual response: {response}",
+            },
+        ]
+    )
+    try:
+        result = json.loads(grade.content)
+        return {"score": result.get("score", 0), "comment": result.get("reasoning", "")}
+    except (json.JSONDecodeError, AttributeError):
+        content = grade.content if hasattr(grade, "content") else str(grade)
+        return {"score": 0, "comment": f"Judge parse error: {content}"}
+
+
+def helpfulness_evaluator(run, example) -> dict:
+    """Score whether the response is helpful, clear, and well-structured."""
+    run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
+
+    response = run_outputs.get("response", "")
+
+    if run_outputs.get("error"):
+        return {"score": 0, "comment": "Agent returned an error"}
+
+    judge = _get_judge()
+    grade = judge.invoke(
+        [
+            {
+                "role": "system",
+                "content": (
+                    "You are grading an AI assistant's response for helpfulness. "
+                    "Score 1 if the response is clear, direct, and helpful. "
+                    "Score 0 if it's confusing, overly verbose, or unhelpful. "
+                    "Respond with ONLY a JSON object: {\"score\": 0 or 1, \"reasoning\": \"...\"}"
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Question: {example.inputs.get('question', '') if hasattr(example, 'inputs') else example.get('inputs', {}).get('question', '')}\n\nResponse: {response}",
+            },
+        ]
+    )
+    try:
+        result = json.loads(grade.content)
+        return {"score": result.get("score", 0), "comment": result.get("reasoning", "")}
+    except (json.JSONDecodeError, AttributeError):
+        content = grade.content if hasattr(grade, "content") else str(grade)
+        return {"score": 0, "comment": f"Judge parse error: {content}"}
+
+
+def tool_usage_evaluator(run, example) -> dict:
+    """Score whether the agent used tools appropriately (used them when expected, didn't when not)."""
+    run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
+    example_outputs = example.outputs if hasattr(example, "outputs") else example.get("outputs", {}) or {}
+
+    if run_outputs.get("error"):
+        return {"score": 0, "comment": "Agent returned an error"}
+
+    expected_tool_use = example_outputs.get("expected_tool_use", None)
+    if expected_tool_use is None:
+        return {"score": 1, "comment": "No tool usage expectation defined"}
+
+    response = run_outputs.get("response", "")
+    used_tool = "Error:" not in response and any(
+        marker in str(run_outputs)
+        for marker in ["calculator", "unit_converter", "tool_calls"]
+    )
+
+    if expected_tool_use and not used_tool:
+        return {"score": 0, "comment": "Expected tool use but agent didn't use tools"}
+    if not expected_tool_use and used_tool:
+        return {"score": 0, "comment": "Agent used tools when not expected"}
+    return {"score": 1, "comment": "Tool usage matched expectations"}
+
+
+# ---------------------------------------------------------------------------
+# Main evaluation
+# ---------------------------------------------------------------------------
+
+
+def run_evaluation(dataset_path: str, prefix: str) -> dict[str, Any]:
+    client = Client()
+
+    examples = load_dataset(dataset_path)
+
+    dataset_name = f"autoresearch-eval-{uuid.uuid4().hex[:8]}"
+    dataset = client.create_dataset(dataset_name, description="Autoresearch evaluation dataset")
+    client.create_examples(
+        inputs=[e["inputs"] for e in examples],
+        outputs=[e["outputs"] for e in examples],
+        dataset_name=dataset_name,
+    )
+
+    results = evaluate(
+        run_agent_for_eval,
+        data=dataset_name,
+        evaluators=[correctness_evaluator, helpfulness_evaluator, tool_usage_evaluator],
+        experiment_prefix=prefix,
+        max_concurrency=4,
+    )
+
+    correctness_scores = []
+    helpfulness_scores = []
+    tool_usage_scores = []
+    num_errors = 0
+
+    for result in results:
+        eval_results = result.get("evaluation_results", {})
+        eval_list = eval_results.get("results", [])
+
+        for er in eval_list:
+            key = er.key if hasattr(er, "key") else er.get("key", "")
+            score = er.score if hasattr(er, "score") else er.get("score", 0)
+            if score is None:
+                score = 0
+            if "correctness" in key:
+                correctness_scores.append(score)
+            elif "helpfulness" in key:
+                helpfulness_scores.append(score)
+            elif "tool_usage" in key:
+                tool_usage_scores.append(score)
+
+        run_output = result.get("run", {})
+        if hasattr(run_output, "outputs"):
+            outputs = run_output.outputs or {}
+        else:
+            outputs = run_output.get("outputs", {}) or {}
+        if outputs.get("error"):
+            num_errors += 1
+
+    avg_correctness = sum(correctness_scores) / len(correctness_scores) if correctness_scores else 0
+    avg_helpfulness = sum(helpfulness_scores) / len(helpfulness_scores) if helpfulness_scores else 0
+    avg_tool_usage = sum(tool_usage_scores) / len(tool_usage_scores) if tool_usage_scores else 0
+    overall = (avg_correctness + avg_helpfulness + avg_tool_usage) / 3
+
+    experiment_url = ""
+    try:
+        ds = client.read_dataset(dataset_name=dataset_name)
+        experiments = list(client.list_experiments(dataset_id=ds.id))
+        if experiments:
+            experiment_url = experiments[0].url or ""
+    except Exception:
+        pass
+
+    summary = {
+        "avg_correctness": avg_correctness,
+        "avg_helpfulness": avg_helpfulness,
+        "avg_tool_usage": avg_tool_usage,
+        "overall_score": overall,
+        "num_examples": len(examples),
+        "num_errors": num_errors,
+        "experiment_url": experiment_url,
+    }
+
+    try:
+        client.delete_dataset(dataset_name=dataset_name)
+    except Exception:
+        pass
+
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run autoresearch agent evaluation")
+    parser.add_argument("--dataset", default=str(SCRIPT_DIR / "dataset.json"), help="Path to dataset JSON")
+    parser.add_argument("--prefix", default="autoresearch", help="Experiment prefix")
+    args = parser.parse_args()
+
+    summary = run_evaluation(args.dataset, args.prefix)
+
+    print("---")
+    for key, value in summary.items():
+        if isinstance(value, float):
+            print(f"{key}: {value:.6f}")
+        else:
+            print(f"{key}: {value}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Adds an `examples/autoresearch` directory inspired by [karpathy/autoresearch](https://github.com/karpathy/autoresearch), adapted for autonomous agent optimization using LangSmith observability and evals. Instead of optimizing ML training code, a coding agent iteratively improves an agent implementation (`agent.py`) by running LangSmith evaluations, keeping improvements, and discarding regressions.

## Test Plan
- [ ] Verify `python agent.py "What is 2+2?"` runs the baseline agent
- [ ] Verify `python run_eval.py` runs the full evaluation pipeline against LangSmith
- [ ] Point a coding agent at `program.md` and confirm it can autonomously iterate