### PR TITLE
Add Claude Code plugin manifest and marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "langsmith-skills",
+  "owner": {
+    "name": "LangChain",
+    "email": "support@langchain.dev"
+  },
+  "metadata": {
+    "description": "Agent skills for observing and evaluating LLM applications with LangSmith"
+  },
+  "plugins": [
+    {
+      "name": "langsmith-skills",
+      "source": ".",
+      "description": "Agent skills for observing and evaluating LLM applications with LangSmith",
+      "homepage": "https://github.com/langchain-ai/langsmith-skills"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "langsmith-skills",
+  "version": "0.1.0",
+  "description": "LangSmith skills for tracing, dataset management, and evaluation pipelines",
+  "author": {
+    "name": "LangChain",
+    "url": "https://langchain.com"
+  },
+  "homepage": "https://docs.smith.langchain.com",
+  "repository": "https://github.com/langchain-ai/langsmith-skills",
+  "license": "MIT",
+  "keywords": ["langsmith", "langchain", "tracing", "evaluation", "datasets", "llm"],
+  "skills": "./config/skills/"
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ To link skills to a specific agent (e.g. Claude Code):
 npx skills add langchain-ai/langsmith-skills --agent claude-code --skill '*' --yes --global
 ```
 
+---
+
+### Claude Code Plugin
+
+Install directly as a [Claude Code plugin](https://code.claude.com/docs/en/plugins):
+
+```bash
+/plugin marketplace add langchain-ai/langsmith-skills
+/plugin install langsmith-skills@langsmith-skills
+```
+
+---
+
 ### Install Script (Claude Code & Deep Agents CLI only)
 
 Alternatively, clone the repo and use the install script:


### PR DESCRIPTION
This PR adds native Claude Code plugin support so users can install the skills directly via `/plugin` instead of relying on `npx skills` or the install script.

Three files added:
* `.claude-plugin/plugin.json` — plugin manifest pointing `skills` at the existing `./config/skills/` directory
* `.claude-plugin/marketplace.json` — marketplace catalog so users can immediately install with `/plugin marketplace add langchain-ai/langsmith-skills`
* README update with a "Claude Code Plugin" install section

The `marketplace.json` is included so users can install the plugin right away from this repo. Longer-term, I'd recommend submitting the plugin to the [official Anthropic marketplace](https://code.claude.com/docs/en/discover-plugins#official-anthropic-marketplace) (`claude-plugins-official`) so it's discoverable from the `/plugin` Discover tab without users needing to add a marketplace first. Submission forms are at:
* **Claude.ai**: [claude.ai/settings/plugins/submit](https://claude.ai/settings/plugins/submit)
* **Console**: [platform.claude.com/plugins/submit](https://platform.claude.com/plugins/submit)

Existing install methods (`npx skills`, `install.sh`) are unchanged.

See also https://github.com/langchain-ai/langchain-skills/pull/30

<details>
<summary>Attribution</summary>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>