### PR TITLE
fix: accept target directory argument in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,22 @@ Alternatively, clone the repo and use the install script:
 # Install for Claude Code in current directory (default)
 ./install.sh
 
+# Install for Claude Code in a specific project directory
+./install.sh ~/my-project
+
 # Install for Claude Code globally
 ./install.sh --global
 
-# Install for DeepAgents CLI in current directory
-./install.sh --deepagents
+# Install for DeepAgents CLI in a specific project directory
+./install.sh --deepagents ~/my-project
 
 # Install for DeepAgents CLI globally (includes agent persona)
 ./install.sh --deepagents --global
 ```
 
-| Flag | Description |
+| Flag / Argument | Description |
 |------|-------------|
+| `DIRECTORY` | Target project directory (default: current directory, ignored with `--global`) |
 | `--claude` | Install for Claude Code (default) |
 | `--deepagents` | Install for DeepAgents CLI |
 | `--global`, `-g` | Install globally instead of current directory |

--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,17 @@ GLOBAL=false
 FORCE=false
 YES=false
 LANGSMITH_ONLY=false
+TARGET_DIR=""
 
 # Usage
 usage() {
-    echo "Usage: $0 [OPTIONS]"
+    echo "Usage: $0 [OPTIONS] [DIRECTORY]"
     echo ""
     echo "Install LangGraph + LangSmith skills for Claude Code or DeepAgents CLI."
+    echo ""
+    echo "Arguments:"
+    echo "  DIRECTORY           Target project directory (default: current directory)"
+    echo "                      Ignored when --global is used"
     echo ""
     echo "Options:"
     echo "  --claude        Install for Claude Code (default)"
@@ -30,10 +35,11 @@ usage() {
     echo "  --help, -h      Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                      # Install for Claude Code in current directory"
-    echo "  $0 --global             # Install for Claude Code globally"
-    echo "  $0 --deepagents -g      # Install for Deep Agents globally (with agent persona)"
-    echo "  $0 -f -y                # Force reinstall without prompts"
+    echo "  $0                          # Install for Claude Code in current directory"
+    echo "  $0 ~/my-project             # Install for Claude Code in ~/my-project"
+    echo "  $0 --global                 # Install for Claude Code globally"
+    echo "  $0 --deepagents ~/my-project  # Install for Deep Agents in ~/my-project"
+    echo "  $0 -f -y                    # Force reinstall without prompts"
     exit 0
 }
 
@@ -67,12 +73,25 @@ while [[ $# -gt 0 ]]; do
         --help|-h)
             usage
             ;;
-        *)
+        -*)
             echo "Unknown option: $1"
             usage
             ;;
+        *)
+            if [ -n "$TARGET_DIR" ]; then
+                echo "Error: multiple directories specified: '$TARGET_DIR' and '$1'"
+                exit 1
+            fi
+            TARGET_DIR="$1"
+            shift
+            ;;
     esac
 done
+
+# Resolve target directory (default to current directory)
+if [ -z "$TARGET_DIR" ]; then
+    TARGET_DIR="$(pwd)"
+fi
 
 # Determine installation directory and whether to include AGENTS.md
 INCLUDE_AGENTS_MD=false
@@ -81,7 +100,7 @@ if [ "$TARGET" = "claude" ]; then
     if [ "$GLOBAL" = true ]; then
         INSTALL_DIR="$HOME/.claude"
     else
-        INSTALL_DIR="$(pwd)/.claude"
+        INSTALL_DIR="$TARGET_DIR/.claude"
     fi
     TOOL_NAME="Claude Code"
 else
@@ -92,7 +111,7 @@ else
         INCLUDE_AGENTS_MD=true
     else
         # Local: just skills, no agent persona
-        INSTALL_DIR="$(pwd)/.deepagents"
+        INSTALL_DIR="$TARGET_DIR/.deepagents"
     fi
     TOOL_NAME="Deep Agents CLI"
 fi


### PR DESCRIPTION
## Summary
- Install script now accepts an optional positional `DIRECTORY` argument for local installs (e.g. `./install.sh ~/my-project`)
- Prevents the common mistake of installing skills into the cloned repo itself instead of the target project
- Fully backwards compatible — omitting the argument defaults to `$(pwd)`

## Test plan
- [x] `./install.sh -y /tmp/test-dir` — installs to `/tmp/test-dir/.claude/skills/`
- [x] `./install.sh -y` — installs to `$(pwd)/.claude/skills/` (backwards compatible)
- [x] `./install.sh --global -y` — installs to `~/.claude/skills/` (ignores positional arg)
- [x] `./install.sh --deepagents -y /tmp/test-dir` — installs to `/tmp/test-dir/.deepagents/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)