### PR TITLE
fix: document --api-key CLI flag as preferred auth method

### DIFF
--- a/config/skills/langsmith-dataset/SKILL.md
+++ b/config/skills/langsmith-dataset/SKILL.md
@@ -11,9 +11,14 @@ Create, manage, and upload evaluation datasets to LangSmith for testing and vali
 Environment Variables
 
 ```bash
-LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # Required
+LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # REQUIRED
 LANGSMITH_PROJECT=your-project-name                   # Check this to know which project has traces
 LANGSMITH_WORKSPACE_ID=your-workspace-id              # Optional: for org-scoped keys
+```
+
+Authentication is REQUIRED: either set the `LANGSMITH_API_KEY` environment variable, or pass the `--api-key` global flag to CLI commands (preferred):
+```bash
+langsmith --api-key $LANGSMITH_API_KEY dataset list
 ```
 
 **IMPORTANT:** Always check the environment variables or `.env` file for `LANGSMITH_PROJECT` before querying or interacting with LangSmith. This tells you which project contains the relevant traces and data. If the LangSmith project is not available, use your best judgement to identify the right one.

--- a/config/skills/langsmith-evaluator/SKILL.md
+++ b/config/skills/langsmith-evaluator/SKILL.md
@@ -11,10 +11,15 @@ Three core components: **(1) Creating Evaluators** - LLM-as-Judge, custom code; 
 Environment Variables
 
 ```bash
-LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # Required
+LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # REQUIRED
 LANGSMITH_PROJECT=your-project-name                   # Check this to know which project has traces
 LANGSMITH_WORKSPACE_ID=your-workspace-id              # Optional: for org-scoped keys
 OPENAI_API_KEY=your_openai_key                        # For LLM as Judge
+```
+
+Authentication is REQUIRED: either set the `LANGSMITH_API_KEY` environment variable, or pass the `--api-key` global flag to CLI commands (preferred):
+```bash
+langsmith --api-key $LANGSMITH_API_KEY evaluator list
 ```
 
 **IMPORTANT:** Always check the environment variables or `.env` file for `LANGSMITH_PROJECT` before querying or interacting with LangSmith. This tells you which project contains the relevant traces and data. If the LangSmith project is not available, use your best judgement to identify the right one.

--- a/config/skills/langsmith-trace/SKILL.md
+++ b/config/skills/langsmith-trace/SKILL.md
@@ -11,9 +11,14 @@ Two main topics: **adding tracing** to your application, and **querying traces**
 Environment Variables
 
 ```bash
-LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # Required
+LANGSMITH_API_KEY=lsv2_pt_your_api_key_here          # REQUIRED
 LANGSMITH_PROJECT=your-project-name                   # Optional: default project
 LANGSMITH_WORKSPACE_ID=your-workspace-id              # Optional: for org-scoped keys
+```
+
+Authentication is REQUIRED: either set the `LANGSMITH_API_KEY` environment variable, or pass the `--api-key` global flag to CLI commands (preferred):
+```bash
+langsmith --api-key $LANGSMITH_API_KEY trace list --project my-project
 ```
 
 **IMPORTANT:** Always check the environment variables or `.env` file for `LANGSMITH_PROJECT` before querying or interacting with LangSmith. This tells you which project contains the relevant traces and data. If the LangSmith project is not available, use your best judgement to identify the right one.


### PR DESCRIPTION
## Summary
- Adds `--api-key` global flag documentation to all three LangSmith skill setup sections
- Marks it as the preferred auth method for CLI commands over inline env vars
- Fixes issue where agents prepend `LANGSMITH_API_KEY=...` to commands, breaking permissioning patterns (e.g. `langsmith trace:*`)

## Test plan
- [ ] Verify skill rendering with updated setup sections
- [ ] Run langsmith benchmarks in skills-benchmarks to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)