### PR TITLE
Add ADLC skill suite: productionalize-agent orchestrator + 5 phase skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langsmith-skills",
-  "version": "0.1.0",
-  "description": "LangSmith skills for tracing, dataset management, and evaluation pipelines",
+  "version": "0.2.0",
+  "description": "LangSmith skills for tracing, dataset management, evaluation, and the full agent development life cycle (build → test → deploy → monitor → improve)",
   "author": {
     "name": "LangChain",
     "url": "https://langchain.com"

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -11,6 +11,15 @@ This project uses skills that contain up-to-date patterns and working reference 
 - **langsmith-dataset** - Invoke for ANY dataset creation from traces
 - **langsmith-evaluator** - Invoke for ANY evaluator creation
 
+### ADLC Skills (idea → production)
+A guided suite that takes an agent through the **Agent Development Life Cycle** (Scope → Build → Test → Deploy → Monitor → Improve). Each phase is a standalone drop-in command; the orchestrator runs them in order. They build on the three skills above.
+- **productionalize-agent** - The ORCHESTRATOR. Invoke for the full guided journey from idea to a deployed, monitored agent. Owns shared state (`.adlc.json`) + conventions.
+- **build-agent** - Scope + Build: scaffold a new agent (or instrument an existing one) until traces flow to LangSmith.
+- **test-agent** - Test: build a dataset + evaluators you trust (align them), then red→green the agent. TDD for agents.
+- **deploy-agent** - Deploy: a thin deployment-client frontend + auth, shipped to LangSmith Deployment or your own infra.
+- **monitor-agent** - Monitor: online evaluators on sampled traffic + dashboards + alerts.
+- **improve-agent** - Improve: failing-trace + 👎-feedback → annotation queue → dataset → CI loop.
+
 ## Debugging Flow: Build → Trace → Dataset → Evaluate
 
 When stuck or debugging, use this powerful workflow:

--- a/config/skills/build-agent/SKILL.md
+++ b/config/skills/build-agent/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: build-agent
+description: "INVOKE when the user runs /build-agent, or wants to scaffold a new agent or get an existing/in-prod agent traced into LangSmith. The Scope+Build phase of the ADLC — works standalone or as a step of /productionalize-agent. Shares .adlc.json + conventions with productionalize-agent. Exit gate: traces flowing to LangSmith."
+version: 1.0.0
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, WebFetch, Skill]
+triggers: ["build an agent", "scaffold an agent", "add tracing to my agent", "instrument my agent"]
+---
+
+<oneliner>
+Scope + Build: turn an idea into a running, traced agent — or instrument an agent you already have. Exit gate = traces flowing to LangSmith.
+</oneliner>
+
+<entry>
+Standalone drop-in: runs on its own OR as the first step of `/productionalize-agent`. On entry:
+1. Load `.adlc.json` at repo root. If absent, create it (see the `<manifest>` in `../productionalize-agent/SKILL.md`).
+2. **Cold entry on an existing/in-prod agent:** bootstrap the manifest by INSPECTING — read the code, `langgraph.json`/framework, and any LangSmith traces; produce the build-spec table to confirm; mark Scope as done where inferable. Don't re-scaffold what exists.
+3. Follow the SHARED conventions (breadcrumb, teach-as-you-go, surface links, manifest contract, defaults, tagging, wrap-up) in `../productionalize-agent/SKILL.md`. Teaching: `../productionalize-agent/scripts/teach.py --print build`.
+</entry>
+
+<prereqs>
+A project to work in (or willingness to scaffold one) and `LANGSMITH_API_KEY` (region-correct `LANGSMITH_ENDPOINT` — see setup in `../productionalize-agent/SKILL.md`).
+</prereqs>
+
+<flow>
+**Iron Law — Build isn't done until you can see it traced in LangSmith.** A chattable agent that emits no traces is not a built agent.
+
+**Scope** (write each answer to `.adlc.json`; ask only what's null):
+- **starting_point?** build_new · existing. (existing → inspect & bootstrap, see `<entry>`.)
+- **Describe it** (open NL) — seeds domain, persona, likely knowledge source, capabilities; pre-fill the manifest, ask only what you can't infer.
+- **goal?** demo · deploy. demo → lightweight (just enough to show); deploy → full downstream rigor.
+- **audience? — the BRANCH POINT, ask early.** Who is this for?
+  - **Myself** → `target=fleet`. **Exit early:** build it and deploy to **fleet** (managed runtime + share via the fleet UI), then stop. The full Test/Deploy/Monitor/Improve production cycle is overkill here — note they can still run those phase skills later if they want.
+  - **My team / company** → `target=fleet`. Same early-exit path.
+  - **Our customers / external users** → `target=langsmith-deployments`. **Continue** the full ADLC — production rigor applies.
+- **learning_level?** low · medium · high — teach-as-you-go verbosity: low = teasers only, medium = teaser + Learn-more/Read-later card, high = full explainers + Read-more links. **Persisted per-user in `user-state.toml` as `teaching_mode`** — read it from there if set (don't re-ask); otherwise ask once and write it back. See the teach-as-you-go convention in `../productionalize-agent/SKILL.md`.
+- Apply audience-derived defaults; confirm in one batch.
+
+**Build:**
+- **Defer framework specifics to the official building skills (don't hardcode — they stay current as the frameworks evolve; this skill owns the *lifecycle*, they own the *how-to-build*).** Invoke **`ecosystem-primer` FIRST** (LangChain vs LangGraph vs Deep Agents vs hybrid selection, install, env setup, which skill next), then the matching builders: **`deep-agents-core`** (+ **`deep-agents-memory`** for backends, **`deep-agents-orchestration`** for subagents/HITL) for an Agent; **`langgraph-fundamentals`** / **`langgraph-cli`** for a Workflow; **`langchain-fundamentals`** for a Prompt/simple agent; and **`langchain-dependencies`** for packages/versions. Map their guidance onto the manifest decisions below.
+- **build_type? (only if build_new) → derives `framework`:**
+  - **Agent** — an AI loop that calls tools → **deepagents**
+  - **Workflow** — a fixed series of steps → **langgraph**
+  - **Prompt** — a single request/reply → `init_chat_model().with_structured_output().invoke()`
+- **framework** — derived from `build_type` (Agent→deepagents · Workflow→langgraph · Prompt→single `init_chat_model` call); for BYO/existing, inferred from inspection. **model?** choose-for-me (deferred — a sweep in Test picks the cheapest passing model; record `{mode:"choose-for-me", resolved:false}`) · i-choose · chat.
+- **Demo seeding (ONLY if `goal=demo` AND `build_new`) — scaffold it with a few realistic weaknesses ON PURPOSE.** A demo where every test passes proves nothing, and a flawless first build makes the Test phase look like ceremony. Leave 2–4 *subtle, plausible* bugs the way real first drafts have them — e.g. a prompt that doesn't enforce grounding (so it can hallucinate balances/figures), a weak out-of-scope refusal, a tool that silently swallows an error, a missing confirmation before a destructive action. Keep them realistic, not cartoonish sabotage, and don't pre-harden. Record them in `.adlc.json` under `demo_seeds: [{id, where, expect}]` so the loop can confirm Test catches them — but do NOT feed the seeds to `/test-agent`; let its red-team discover them independently, then cross-check. For `goal=deploy`, build it right the first time — **no seeding.**
+- **capabilities?** MULTISELECT over deepagents OOTB pieces, two groups:
+  - *Already on (defaults, read-only):* TodoList, Filesystem, SubAgent, Summarization, PatchToolCalls, Anthropic prompt-caching — show for transparency, don't offer to "enable".
+  - *Opt-in:* human-approval (`interrupt_on`), long-term memory (StoreBackend), subagents, skills, **computer use**, code-exec (sandbox backend), rubric. Tag each `(recommended)` from the manifest.
+  - **If human-approval is on, specify WHICH tool calls are gated** — don't blanket-pause everything. Ask which tools need approval (the risky/irreversible ones: money movement, deletes, external writes) and set `interrupt_on={"<tool>": True, ...}`. Record the gated list in the manifest under `hitl` (e.g. `["transfer_funds","delete_account"]`); read-only tools should run without interruption.
+- **tools?** the agent's domain tools. Offer **MCP integrations** (wire an MCP server's tools in) alongside hand-written Python tools and the knowledge-source retriever. Record under `tools`.
+- **knowledge_source?** docs path · url · generate · none.  **interaction?** conversational · headless (agents only).
+- **Tracing is ON by default** — the substrate; state it, don't ask.
+- **Instrument a BYO/existing agent (do this FIRST — tracing is the substrate):** deepagents/LangChain/LangGraph → native (set `LANGSMITH_*` env) · Claude/OpenAI SDK → `from langsmith.wrappers import wrap_anthropic`/`wrap_openai` · home-grown → `@traceable`.
+- **First-trace moment:** after the FIRST successful invocation, confirm the trace reached LangSmith and give the link to that exact run (`https://<host>/o/<org>/projects/p/<project_id>?...&trace_id=<run_id>`).
+- **Local run (`make run`) — figure out + TEST how this agent runs locally before exiting Build.** Emit a `Makefile` whose `run` target spawns the **backend** (however the agent is served — e.g. `langgraph dev`) and, if a frontend is in play, the **frontend** together (the exact commands depend on the framework/FE — work them out for THIS agent). Actually run it once to confirm both come up; set **`local_run_ready: true`** in `.adlc.json` only after `make run` works (else `false` + note the gap in `pending_reminders`). This is part of the exit gate.
+- **Let them interact (zero-install options):** auto-open **LangGraph Studio** chat mode (`https://<host>/o/<org>/studio/connect?mode=chat`, or `?baseUrl=<tunnel>` locally), AND share the hosted **agent-chat-ui** — a prebuilt drop-in chat app, no install: `https://agentchat.vercel.app/?apiUrl=<local-or-tunnel-url>&assistantId=<graphId>`. Do NOT ask which production frontend here — that's `/deploy-agent`.
+- **EXIT GATE = traces confirmed in LangSmith + `make run` verified (`local_run_ready`)** — NOT a polished agent.
+- **Build-spec sign-off (REQUIRED):** render the table (tools · middleware [defaults+opt-ins] · knowledge/docs · backend · code-exec · interrupt/HITL · integrations · how-to-run · deploy target), mark who chose each + flag gaps, get `AskUserQuestion` sign-off. For existing agents, inspect the code and produce the SAME table.
+Hand back to `/productionalize-agent` (or suggest `/test-agent`) once traces are flowing.
+</flow>

--- a/config/skills/deploy-agent/SKILL.md
+++ b/config/skills/deploy-agent/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: deploy-agent
+description: "INVOKE when the user runs /deploy-agent, or wants to ship / put an agent into production / give it a frontend. The Deploy phase of the ADLC — works standalone or as a step of /productionalize-agent. Picks a deployment-client frontend, auth, and ships to LangSmith Deployment or your own infra."
+version: 1.0.0
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, WebFetch, Skill]
+triggers: ["deploy my agent", "ship my agent", "put my agent in production", "add a frontend"]
+---
+
+<oneliner>
+Put the agent where its users are: a thin deployment-client frontend + auth, shipped to LangSmith Deployment (or your infra).
+</oneliner>
+
+<entry>
+Standalone drop-in. On entry:
+1. Load `.adlc.json`; if absent, bootstrap by inspecting the agent + traces and mark earlier phases done.
+2. **Prereq:** a working, traced agent. Recommend (don't require) trusted evals + a CI gate first — if absent, offer a quick `/test-agent`, or proceed and add CI later.
+3. Follow the SHARED conventions in `../productionalize-agent/SKILL.md`. Teaching: `../productionalize-agent/scripts/teach.py --print deploy`.
+</entry>
+
+<prereqs>
+A working, traced agent. For an external/production audience: confirm auth.
+</prereqs>
+
+<flow>
+**Iron Law — the frontend is a client of the deployment, never the agent itself.** The agent runs ON the deployment; the UI only streams.
+
+SKIP the public-facing questions if `host=local-only`.
+- **host?** langsmith-deployments (recommended) · own-infra · local-only / skip-for-now (defer the actual ship → `pending_reminders`; the agent is deploy-ready, cloud is a connect step).
+- **auth?** (only if hosted externally) oauth · api-key · sso · none.
+- **frontend?** Tiered choice, ranked by involvement vs production-readiness. All except "own" and "none" are thin **deployment CLIENTS** (point at the deployment URL; agent runs ON the deployment, UI only streams; same code repoints local→cloud by changing one URL):
+  1. **I have my own** — wire it to the deployment URL via `langgraph_sdk` / REST.
+  2. **CopilotKit** — most involved, most production-ready. Needs **Node** + `CopilotKitMiddleware()` in the agent graph (two-sided). Uses `agents: { name: new LangGraphAgent({ deploymentUrl, graphId }) }` (`langGraphPlatformEndpoint` deprecated in runtime 1.6x).
+  3. **assistant-ui** — medium; a headless React **component library** you build into your own app (wire `useStream` + render `<Thread/>`). First-class LangGraph support, deep customization.
+  4. **agent-chat-ui** — low effort; a **prebuilt drop-in chat app** (Next.js) for any LangGraph agent. Clone + `pnpm dev` pointed at the deployment URL + graph id, or use the hosted `agentchat.vercel.app`. Great for fast/standard chat; for prod use its API-passthrough/auth path.
+  5. **Streamlit client** — Python, **no Node**; a thin `langgraph_sdk.get_client(url=...)` client. (NOT in-process — that bypasses the deployment.)
+  6. **No frontend** — LangGraph/LangSmith Studio against the deployment. Demo only.
+- **hardening?** evals+ci · smoke · none. (evals+ci → emit `.github/workflows/` that runs the eval suite on PRs.)
+- **Ship the backend:** LangSmith Deployment (UI connect / `langgraph deploy`) · own infra (`langgraph build` → container) · skip. Surface every URL; record to `resources[]`.
+- **Defer deploy mechanics to the official skills (current commands/flows):** invoke **`managed-deep-agents`** for LangSmith-managed Deep Agents (deepagents-cli, Python/TS SDKs, React `useStream`, MCP tools, interrupts) and **`langgraph-cli`** for `langgraph build` / `deploy` / `langgraph.json`. This skill owns the deploy *decisions* (host, auth, frontend, CI); they own the exact commands.
+</flow>

--- a/config/skills/improve-agent/SKILL.md
+++ b/config/skills/improve-agent/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: improve-agent
+description: "INVOKE when the user runs /improve-agent, or wants to close the feedback loop / self-improve / continuously improve an agent. The Improve phase of the ADLC — works standalone or as a step of /productionalize-agent. Wires failing traces + 👎 feedback back into the dataset; links LangSmith Engine."
+version: 1.0.0
+allowed-tools: [Read, Write, Edit, Bash, AskUserQuestion, WebFetch]
+triggers: ["improve my agent", "close the loop", "self-improve", "auto-improve my agent"]
+---
+
+<oneliner>
+Close the loop so the agent gets better over time: failing traces + thumbs-down feedback → annotation queue → dataset → CI.
+</oneliner>
+
+<entry>
+Standalone drop-in. On entry:
+1. Load `.adlc.json`; if absent, bootstrap by inspecting the agent + traces; mark earlier phases done.
+2. **Prereq: tracing + evals + monitoring** (the loop connects existing pieces). Missing one → point to `/test-agent` (evals) or `/monitor-agent` (online evals) first.
+3. Follow the SHARED conventions in `../productionalize-agent/SKILL.md`. Teaching: `../productionalize-agent/scripts/teach.py --print improve`.
+</entry>
+
+<prereqs>
+A traced agent with an eval suite and (ideally) online monitoring.
+</prereqs>
+
+<flow>
+**Iron Law — only improve against evals you trust.** Optimizing toward an unaligned metric makes the agent worse, confidently.
+
+- **self_improve?** yes/no. Requires tracing + evals + monitoring (gate here). If yes, wire the loop: online-eval failures → failing traces → dataset → re-eval (CI guards it).
+- **Auto-route negative feedback?** Offer a `/runs/rules` automation that adds any **thumbs-down**-feedback trace to the annotation queue (filter on the thumbs-down feedback key → add-to-annotation-queue action). Closes the human-feedback side: 👎 → triage queue → dataset → CI. Wire now / skip / defer → `pending_reminders`. (Confirm the app's thumbs-down feedback key.)
+- **LangSmith Engine** auto-proposes assertions/examples from recurring production issues (and prompt/model fixes). **Can't be enabled via API — link the user to it in the LangSmith UI**; defer → `pending_reminders` if "later".
+- Optional, evals-adjudicated, user-driven: harness tuning / model selection to raise scores. (Improving the agent's IQ is the user's call; this skill wires the loop.)
+- **success_criteria?** open text (feedback signals + online evals).
+</flow>

--- a/config/skills/monitor-agent/SKILL.md
+++ b/config/skills/monitor-agent/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: monitor-agent
+description: "INVOKE when the user runs /monitor-agent, or wants production monitoring / online evals / alerts / dashboards for an agent. The Monitor phase of the ADLC — works standalone or as a step of /productionalize-agent. Gated on TRACING (not cloud deploy). Uses langsmith-trace + langsmith-evaluator."
+version: 1.0.0
+allowed-tools: [Read, Write, Edit, Bash, AskUserQuestion, WebFetch]
+triggers: ["monitor my agent", "online evals", "set up alerts", "production dashboard"]
+---
+
+<oneliner>
+Watch the agent on live traffic: online evaluators on a sample of traces, dashboards, and alerts.
+</oneliner>
+
+<entry>
+Standalone drop-in — the prime "harden an in-prod agent" entry point. On entry:
+1. Load `.adlc.json`; if absent, bootstrap by inspecting the agent + traces; mark earlier phases done.
+2. **Prereq: tracing is live** (NOT a cloud deploy — dev/test/red-team runs count). If traces exist you're already monitoring; surface the project dashboard immediately. If trusted evals exist, offer to promote them online; if not, offer a quick `/test-agent` to define dimensions, or just wire dashboards/alerts.
+3. Follow the SHARED conventions in `../productionalize-agent/SKILL.md`. Teaching: `../productionalize-agent/scripts/teach.py --print monitor`.
+</entry>
+
+<prereqs>
+A traced agent (a LangSmith project with runs). Online evals need at least one eval dimension (reuse Test's, or define here).
+</prereqs>
+
+<flow>
+**Iron Law — monitoring needs traces, not a cloud deploy.** If traces flow, you're already monitoring; start there.
+
+**Monitor is gated on TRACING (live since Build), NOT a cloud deploy** — dev/test/red-team runs already populate the dashboards.
+- **Surface the live dashboard URL** first (it's populated the moment traces flow).
+- **monitoring?** If yes: ask **which checks to run online** (multiselect over the project's judges — groundedness/scope/tool-safety…) and a **sampling rate** (% of live traces; online evals cost a judge call per sampled run, so 100% is rarely worth it). Create **online evaluators** (run-rules) on the project at that rate. Surface the cost/coverage tradeoff.
+- **ci_watches?** (multi) cost · quality · safety.
+- **alerts?** Ask which signals — errors/failures · latency spikes · feedback-score drops · cost-per-trace spikes — and whether to set up now (LangSmith **alerts UI** — point them there; UI-configured, not scripted), skip, or **defer → `pending_reminders`**. Alerts can notify via **Slack / email / PagerDuty / webhook** — see [LangSmith alerts](https://docs.langchain.com/langsmith/alerts) for channel setup.
+- **hitl?** route flagged/generated examples through an **annotation queue** for human review (edit input/output, write/adjust assertions, Add to Dataset). Use for curating red-team examples and triaging production thumbs-downs. Queues are ADD-feedback, not edit-existing.
+</flow>

--- a/config/skills/productionalize-agent/.gitignore
+++ b/config/skills/productionalize-agent/.gitignore
@@ -1,0 +1,2 @@
+# Per-user local state (shared across projects, never committed)
+user-state.toml

--- a/config/skills/productionalize-agent/README.html
+++ b/config/skills/productionalize-agent/README.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>productionalize-agent — get your agent into production, backed by the ADLC</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2032%2032%27%3E%3Crect%20width%3D%2732%27%20height%3D%2732%27%20rx%3D%277%27%20fill%3D%27%230D1322%27%2F%3E%3Cg%20transform%3D%27translate%284%2C4%29%27%20fill%3D%27none%27%20stroke%3D%27%237FC8FF%27%20stroke-width%3D%271.8%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20d%3D%27M16.023%209.348h4.992v-.001M2.985%2019.644v-4.992m0%200h4.992m-4.993%200%203.181%203.183a8.25%208.25%200%200%200%2013.803-3.7M4.031%209.865a8.25%208.25%200%200%201%2013.803-3.7l3.181%203.182m0-4.991v4.99%27%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=IBM+Plex+Mono:wght@300;400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #030710;
+    --bg-2: #0D1322;
+    --card: #0D1322;
+    --card-2: #161F34;
+    --border: rgba(255,255,255,.08);
+    --text: #F2FAFF;
+    --muted: rgba(255,255,255,.6);
+    --accent: #7FC8FF;
+    --accent-bright: #006DDD;
+    --warn: #FBB0A5;
+    --red: #DB8C8C;
+    --red-bd: #8C3D3D;
+    --green: #8CDB9B;
+    --green-bd: #3D8C5C;
+    --radius: 12px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    font-weight: 300;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  code, .mono { font-family: 'IBM Plex Mono', ui-monospace, monospace; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .section { padding: 88px 0; border-top: 1px solid var(--border); }
+  .eyebrow { font-family: 'IBM Plex Mono', monospace; font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: var(--accent); font-weight: 500; margin-bottom: 16px; }
+  h2 { font-family: 'IBM Plex Mono', monospace; font-size: 27px; font-weight: 400; letter-spacing: 0; line-height: 1.15; margin-bottom: 12px; }
+  h3 { font-size: 17px; font-weight: 600; letter-spacing: -.01em; margin-bottom: 6px; }
+  p.lead { color: var(--muted); font-size: 17px; font-weight: 300; max-width: 70ch; }
+
+  /* hero */
+  .hero {
+    position: relative; overflow: hidden;
+    background:
+      radial-gradient(1100px 500px at 78% -10%, rgba(127,200,255,.12), transparent 60%),
+      radial-gradient(900px 500px at 10% 0%, rgba(0,109,221,.10), transparent 55%),
+      var(--bg);
+    padding: 120px 0 80px;
+  }
+  .badge-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 28px; }
+  .badge {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px; font-weight: 400; color: var(--muted);
+    border: 1px solid var(--border); background: rgba(255,255,255,.02);
+    padding: 6px 12px; border-radius: 999px;
+  }
+  .badge b { color: var(--accent); font-weight: 500; }
+  .hero h1 {
+    font-size: clamp(34px, 6vw, 60px); font-weight: 300; letter-spacing: -.02em; line-height: 1.06;
+  }
+  .grad { color: var(--accent); }
+  .hero .sub { margin-top: 22px; font-size: 19px; font-weight: 300; color: var(--text); max-width: 64ch; }
+  .hero .sub .em { color: var(--accent); font-weight: 500; }
+  .cmd {
+    margin-top: 34px; display: inline-flex; align-items: center; gap: 12px;
+    background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+    padding: 12px 18px; font-family: 'IBM Plex Mono', monospace; font-size: 15px;
+  }
+  .cmd .dollar { color: var(--accent); }
+  .cmd .blink, .cmdmap-label .blink { width: 8px; height: 16px; background: var(--accent); display: inline-block; animation: blink 1.1s steps(2) infinite; vertical-align: middle; margin-left: 1px; }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  /* pipeline */
+  .pipe { display: flex; align-items: stretch; gap: 0; flex-wrap: wrap; margin-top: 28px; }
+  .stage {
+    flex: 1 1 0; min-width: 150px; position: relative;
+    background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+    padding: 16px 16px 18px; margin: 6px;
+  }
+  .stage .n { font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: var(--accent); }
+  .stage h4 { font-size: 15px; font-weight: 600; margin: 4px 0 6px; }
+  .stage p { font-size: 13px; color: var(--muted); line-height: 1.5; }
+  .stage.gate { border-color: rgba(127,200,255,.4); box-shadow: 0 0 0 1px rgba(127,200,255,.15) inset; }
+
+  /* grid cards */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; margin-top: 28px; }
+  .card {
+    background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 22px; transition: transform .15s ease, border-color .15s ease;
+  }
+  .card:hover { transform: translateY(-3px); border-color: rgba(127,200,255,.35); }
+  .card .ic { font-size: 22px; margin-bottom: 12px; }
+  .card p { color: var(--muted); font-size: 14.5px; }
+
+  /* problem/solution split */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-top: 26px; }
+  .panel { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 24px; }
+  .panel.problem { border-left: 3px solid var(--red-bd); }
+  .panel.solution { border-left: 3px solid var(--green-bd); }
+  .panel ul { list-style: none; margin-top: 10px; }
+  .panel li { padding: 6px 0 6px 24px; position: relative; color: var(--muted); font-size: 14.5px; }
+  .panel.problem li::before { content: "✕"; position: absolute; left: 0; color: var(--red); }
+  .panel.solution li::before { content: "✓"; position: absolute; left: 0; color: var(--green); }
+
+  table.feat { width: 100%; border-collapse: collapse; margin-top: 24px; font-size: 14.5px; }
+  table.feat th { text-align: left; font-family: 'IBM Plex Mono', monospace; color: var(--accent); font-size: 12px; font-weight: 500; letter-spacing: .08em; text-transform: uppercase; padding: 10px 14px; border-bottom: 1px solid var(--border); }
+  table.feat td { padding: 13px 14px; border-bottom: 1px solid var(--border); color: var(--muted); vertical-align: top; }
+  table.feat td b { color: var(--text); font-weight: 500; }
+  table.feat tr:hover td { background: rgba(255,255,255,.015); }
+
+  .pill { display: inline-block; font-family: 'IBM Plex Mono', monospace; font-size: 12px; background: rgba(127,200,255,.1); color: var(--accent); border: 1px solid rgba(127,200,255,.25); padding: 2px 8px; border-radius: 6px; }
+
+  footer { padding: 88px 0 64px; border-top: 1px solid var(--border); color: var(--muted); font-size: 14px; }
+  footer .goal { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 22px 24px; margin-bottom: 26px; }
+  footer .goal b { color: var(--text); }
+
+  @media (max-width: 720px) { .split { grid-template-columns: 1fr; } }
+  .qflow{margin-top:26px;display:flex;flex-direction:column;gap:10px}
+  .qphase{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:14px 16px}
+  .qphase .qp{display:inline-block;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent);font-weight:500;margin-bottom:8px}
+  .qrow{font-size:14px;color:var(--muted);padding:4px 0;line-height:1.7}
+  .qrow b{color:var(--text);font-weight:500}
+  .qopt{display:inline-block;font-family:'IBM Plex Mono',monospace;font-size:12px;background:rgba(127,200,255,.06);border:1px solid rgba(127,200,255,.2);border-radius:6px;padding:3px 9px;margin:3px 4px 3px 7px;color:var(--text)}
+  .bigquote{font-size:clamp(26px,4.5vw,42px);font-weight:300;letter-spacing:-.02em;line-height:1.2;color:var(--text);margin:0 0 6px;max-width:22ch}
+  .bigquote cite{display:block;margin-top:16px;font-family:'IBM Plex Mono',monospace;font-size:15px;font-weight:400;font-style:normal;color:var(--accent)}
+  .cmdmap{margin-top:30px;border:1px solid rgba(127,200,255,.45);border-radius:14px;padding:18px 20px;background:rgba(127,200,255,.05)}
+  .cmdmap-label{font-family:'IBM Plex Mono',monospace;font-size:16px;font-weight:500;color:var(--accent);margin-bottom:14px}
+  .cmdmap-label span{color:var(--muted);font-family:'Inter',sans-serif;font-weight:300;font-size:13px}
+  .cmdmap-inner{display:flex;flex-wrap:wrap;gap:10px}
+  .cmdbox{font-family:'IBM Plex Mono',monospace;font-size:14px;background:var(--bg-2);border:1px solid var(--border);border-radius:8px;padding:9px 14px;color:var(--text)}
+  .cmdmap-note{margin-top:14px;font-size:13.5px;color:var(--muted)}
+
+/* Heroicons v2.1.5 (CSS mask, color via currentColor) */
+.ico{display:inline-block;width:1em;height:1em;vertical-align:-0.15em;background:currentColor;-webkit-mask:var(--i) center/contain no-repeat;mask:var(--i) center/contain no-repeat}
+.ico-bolt{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22m3.75%2013.5%2010.5-11.25L12%2010.5h8.25L9.75%2021.75%2012%2013.5H3.75Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-arrow-path{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M16.023%209.348h4.992v-.001M2.985%2019.644v-4.992m0%200h4.992m-4.993%200%203.181%203.183a8.25%208.25%200%200%200%2013.803-3.7M4.031%209.865a8.25%208.25%200%200%201%2013.803-3.7l3.181%203.182m0-4.991v4.99%22%2F%3E%3C%2Fsvg%3E")}
+.ico-rocket-launch{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M15.59%2014.37a6%206%200%200%201-5.84%207.38v-4.8m5.84-2.58a14.98%2014.98%200%200%200%206.16-12.12A14.98%2014.98%200%200%200%209.631%208.41m5.96%205.96a14.926%2014.926%200%200%201-5.841%202.58m-.119-8.54a6%206%200%200%200-7.381%205.84h4.8m2.581-5.84a14.927%2014.927%200%200%200-2.58%205.84m2.699%202.7c-.103.021-.207.041-.311.06a15.09%2015.09%200%200%201-2.448-2.448%2014.9%2014.9%200%200%201%20.06-.312m-2.24%202.39a4.493%204.493%200%200%200-1.757%204.306%204.493%204.493%200%200%200%204.306-1.758M16.5%209a1.5%201.5%200%201%201-3%200%201.5%201.5%200%200%201%203%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-viewfinder-circle{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M7.5%203.75H6A2.25%202.25%200%200%200%203.75%206v1.5M16.5%203.75H18A2.25%202.25%200%200%201%2020.25%206v1.5m0%209V18A2.25%202.25%200%200%201%2018%2020.25h-1.5m-9%200H6A2.25%202.25%200%200%201%203.75%2018v-1.5M15%2012a3%203%200%201%201-6%200%203%203%200%200%201%206%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-face-frown{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M15.182%2016.318A4.486%204.486%200%200%200%2012.016%2015a4.486%204.486%200%200%200-3.198%201.318M21%2012a9%209%200%201%201-18%200%209%209%200%200%201%2018%200ZM9.75%209.75c0%20.414-.168.75-.375.75S9%2010.164%209%209.75%209.168%209%209.375%209s.375.336.375.75Zm-.375%200h.008v.015h-.008V9.75Zm5.625%200c0%20.414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375%200h.008v.015h-.008V9.75Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-document-text{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M19.5%2014.25v-2.625a3.375%203.375%200%200%200-3.375-3.375h-1.5A1.125%201.125%200%200%201%2013.5%207.125v-1.5a3.375%203.375%200%200%200-3.375-3.375H8.25m0%2012.75h7.5m-7.5%203H12M10.5%202.25H5.625c-.621%200-1.125.504-1.125%201.125v17.25c0%20.621.504%201.125%201.125%201.125h12.75c.621%200%201.125-.504%201.125-1.125V11.25a9%209%200%200%200-9-9Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-academic-cap{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M4.26%2010.147a60.438%2060.438%200%200%200-.491%206.347A48.62%2048.62%200%200%201%2012%2020.904a48.62%2048.62%200%200%201%208.232-4.41%2060.46%2060.46%200%200%200-.491-6.347m-15.482%200a50.636%2050.636%200%200%200-2.658-.813A59.906%2059.906%200%200%201%2012%203.493a59.903%2059.903%200%200%201%2010.399%205.84c-.896.248-1.783.52-2.658.814m-15.482%200A50.717%2050.717%200%200%201%2012%2013.489a50.702%2050.702%200%200%201%207.74-3.342M6.75%2015a.75.75%200%201%200%200-1.5.75.75%200%200%200%200%201.5Zm0%200v-3.675A55.378%2055.378%200%200%201%2012%208.443m-7.007%2011.55A5.981%205.981%200%200%200%206.75%2015.75v-1.5%22%2F%3E%3C%2Fsvg%3E")}
+.ico-link{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M13.19%208.688a4.5%204.5%200%200%201%201.242%207.244l-4.5%204.5a4.5%204.5%200%200%201-6.364-6.364l1.757-1.757m13.35-.622%201.757-1.757a4.5%204.5%200%200%200-6.364-6.364l-4.5%204.5a4.5%204.5%200%200%200%201.242%207.244%22%2F%3E%3C%2Fsvg%3E")}
+.ico-beaker{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M9.75%203.104v5.714a2.25%202.25%200%200%201-.659%201.591L5%2014.5M9.75%203.104c-.251.023-.501.05-.75.082m.75-.082a24.301%2024.301%200%200%201%204.5%200m0%200v5.714c0%20.597.237%201.17.659%201.591L19.8%2015.3M14.25%203.104c.251.023.501.05.75.082M19.8%2015.3l-1.57.393A9.065%209.065%200%200%201%2012%2015a9.065%209.065%200%200%200-6.23-.693L5%2014.5m14.8.8%201.402%201.402c1.232%201.232.65%203.318-1.067%203.611A48.309%2048.309%200%200%201%2012%2021c-2.773%200-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5%2014.5%22%2F%3E%3C%2Fsvg%3E")}
+.ico-signal{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M9.348%2014.652a3.75%203.75%200%200%201%200-5.304m5.304%200a3.75%203.75%200%200%201%200%205.304m-7.425%202.121a6.75%206.75%200%200%201%200-9.546m9.546%200a6.75%206.75%200%200%201%200%209.546M5.106%2018.894c-3.808-3.807-3.808-9.98%200-13.788m13.788%200c3.808%203.807%203.808%209.98%200%2013.788M12%2012h.008v.008H12V12Zm.375%200a.375.375%200%201%201-.75%200%20.375.375%200%200%201%20.75%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-puzzle-piece{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M14.25%206.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003%200-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25%201.875c0%20.369.128.713.349%201.003.215.283.401.604.401.959v0a.64.64%200%200%201-.657.643%2048.39%2048.39%200%200%201-4.163-.3c.186%201.613.293%203.25.315%204.907a.656.656%200%200%201-.658.663v0c-.355%200-.676-.186-.959-.401a1.647%201.647%200%200%200-1.003-.349c-1.036%200-1.875%201.007-1.875%202.25s.84%202.25%201.875%202.25c.369%200%20.713-.128%201.003-.349.283-.215.604-.401.959-.401v0c.31%200%20.555.26.532.57a48.039%2048.039%200%200%201-.642%205.056c1.518.19%203.058.309%204.616.354a.64.64%200%200%200%20.657-.643v0c0-.355-.186-.676-.401-.959a1.647%201.647%200%200%201-.349-1.003c0-1.035%201.008-1.875%202.25-1.875%201.243%200%202.25.84%202.25%201.875%200%20.369-.128.713-.349%201.003-.215.283-.4.604-.4.959v0c0%20.333.277.599.61.58a48.1%2048.1%200%200%200%205.427-.63%2048.05%2048.05%200%200%200%20.582-4.717.532.532%200%200%200-.533-.57v0c-.355%200-.676.186-.959.401-.29.221-.634.349-1.003.349-1.035%200-1.875-1.007-1.875-2.25s.84-2.25%201.875-2.25c.37%200%20.713.128%201.003.349.283.215.604.401.96.401v0a.656.656%200%200%200%20.658-.663%2048.422%2048.422%200%200%200-.37-5.36c-1.886.342-3.81.574-5.766.689a.578.578%200%200%201-.61-.58v0Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-hand-thumb-down{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M7.498%2015.25H4.372c-1.026%200-1.945-.694-2.054-1.715a12.137%2012.137%200%200%201-.068-1.285c0-2.848.992-5.464%202.649-7.521C5.287%204.247%205.886%204%206.504%204h4.016a4.5%204.5%200%200%201%201.423.23l3.114%201.04a4.5%204.5%200%200%200%201.423.23h1.294M7.498%2015.25c.618%200%20.991.724.725%201.282A7.471%207.471%200%200%200%207.5%2019.75%202.25%202.25%200%200%200%209.75%2022a.75.75%200%200%200%20.75-.75v-.633c0-.573.11-1.14.322-1.672.304-.76.93-1.33%201.653-1.715a9.04%209.04%200%200%200%202.86-2.4c.498-.634%201.226-1.08%202.032-1.08h.384m-10.253%201.5H9.7m8.075-9.75c.01.05.027.1.05.148.593%201.2.925%202.55.925%203.977%200%201.487-.36%202.89-.999%204.125m.023-8.25c-.076-.365.183-.75.575-.75h.908c.889%200%201.713.518%201.972%201.368.339%201.11.521%202.287.521%203.507%200%201.553-.295%203.036-.831%204.398-.306.774-1.086%201.227-1.918%201.227h-1.053c-.472%200-.745-.556-.5-.96a8.95%208.95%200%200%200%20.303-.54%22%2F%3E%3C%2Fsvg%3E")}
+.ico-clock{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M12%206v6h4.5m4.5%200a9%209%200%201%201-18%200%209%209%200%200%201%2018%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-book-open{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M12%206.042A8.967%208.967%200%200%200%206%203.75c-1.052%200-2.062.18-3%20.512v14.25A8.987%208.987%200%200%201%206%2018c2.305%200%204.408.867%206%202.292m0-14.25a8.966%208.966%200%200%201%206-2.292c1.052%200%202.062.18%203%20.512v14.25A8.987%208.987%200%200%200%2018%2018a8.967%208.967%200%200%200-6%202.292m0-14.25v14.25%22%2F%3E%3C%2Fsvg%3E")}
+.badge .ico,.cmdmap-note .ico{color:var(--accent);margin-right:5px}
+.qrow .ico{color:var(--accent);margin:0 2px;vertical-align:-0.16em}
+.card .ic .ico{color:var(--accent);width:26px;height:26px}
+.frown-ico{color:var(--red);margin-left:4px}
+
+  /* —— deep-agent-style: centered light-blue section headers —— */
+  .section .eyebrow{text-align:center}
+  h2{font-family:'Inter',system-ui,sans-serif;font-size:clamp(28px,4vw,40px);font-weight:300;letter-spacing:-.02em;line-height:1.12;color:var(--accent);text-align:center;margin-bottom:14px}
+  .section > .wrap > p.lead{margin-left:auto;margin-right:auto;text-align:center}
+  .bigquote{margin-left:auto;margin-right:auto;text-align:center}
+  .panel,.qphase,table.feat,.card,.stepcard,.lc{text-align:left}
+  /* numbered "how it works" cards */
+  .steps{display:grid;grid-template-columns:repeat(auto-fit,minmax(258px,1fr));gap:18px;margin-top:34px}
+  .stepcard{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:30px 26px;text-align:center;transition:border-color .15s ease}
+  .stepcard:hover{border-color:rgba(127,200,255,.35)}
+  .stepnum{width:34px;height:34px;border-radius:9px;background:var(--card-2);border:1px solid var(--border);color:var(--accent);font-family:'IBM Plex Mono',monospace;font-size:14px;display:flex;align-items:center;justify-content:center;margin:0 auto 18px}
+  .stepcard h3{font-size:19px;font-weight:500;letter-spacing:-.01em;margin-bottom:10px;text-align:center}
+  .stepcard p{color:var(--muted);font-size:14px;margin:0 auto;max-width:32ch}
+  .cta-row{text-align:center;margin-top:30px}
+  .cta-ghost{display:inline-block;font-family:'IBM Plex Mono',monospace;font-size:14px;color:var(--text);border:1px solid var(--border);border-radius:10px;padding:11px 22px}
+  .cta-ghost:hover{border-color:var(--accent);text-decoration:none}
+  /* lifecycle accordion + visual */
+  .lc{display:grid;grid-template-columns:1fr 1fr;gap:36px;align-items:center;margin-top:34px}
+  details.acc-item{border-bottom:1px solid var(--border);padding:16px 2px}
+  details.acc-item summary{list-style:none;cursor:pointer;display:flex;gap:13px;align-items:center}
+  details.acc-item summary::-webkit-details-marker{display:none}
+  .acc-ico{flex:none;width:34px;height:34px;border-radius:9px;background:var(--card-2);border:1px solid var(--border);color:var(--accent);display:flex;align-items:center;justify-content:center}
+  .acc-ico .ico{width:18px;height:18px}
+  .acc-tt{flex:1}.acc-tt h4{font-size:17px;font-weight:500;color:var(--text)}.acc-tt .s{font-size:13px;color:var(--muted);margin-top:1px}
+  .acc-plus{color:var(--muted);font-family:'IBM Plex Mono',monospace;font-size:18px}
+  .acc-plus::before{content:"+"} details[open] .acc-plus::before{content:"\2013"}
+  .acc-body{color:var(--muted);font-size:14px;margin:12px 0 2px 47px;max-width:48ch}
+  .acc-body.qbody{max-width:none;margin-top:8px}
+  .acc-link{display:inline-block;margin-top:10px;font-size:13.5px;color:var(--accent)}
+  .lc-visual{background:linear-gradient(180deg,var(--card),#0a1422);border:1px solid var(--border);border-radius:18px;padding:26px;box-shadow:0 0 90px rgba(127,200,255,.09)}
+  .lc-visual .vh{font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);margin-bottom:14px}
+  .vstep{display:flex;align-items:center;gap:10px;padding:9px 11px;border:1px solid var(--border);border-radius:9px;margin:7px 0;font-size:13.5px;color:var(--muted);background:rgba(255,255,255,.01)}
+  .vstep b{color:var(--text);font-weight:500}
+  .vstep.done{border-color:rgba(140,219,155,.35)} .vstep.done .g{color:var(--green)}
+  .vstep.cur{border-color:rgba(127,200,255,.5);box-shadow:0 0 0 1px rgba(127,200,255,.2) inset} .vstep.cur .g{color:var(--accent)}
+  .vstep .g{font-family:'IBM Plex Mono',monospace;font-variant-emoji:text}
+  @media(max-width:820px){.lc{grid-template-columns:1fr}}
+  /* —— onboarding simulation (fake terminal) —— */
+  .sim{background:#05080d;border:1px solid var(--border);border-radius:14px;overflow:hidden;box-shadow:0 0 90px rgba(127,200,255,.07);max-width:760px;margin:34px auto 0}
+  .sim-bar{display:flex;align-items:center;gap:7px;padding:11px 14px;border-bottom:1px solid var(--border);background:rgba(255,255,255,.02)}
+  .sim-bar .dot{width:11px;height:11px;border-radius:50%}
+  .sim-bar .d1{background:#ff5f57}.sim-bar .d2{background:#febc2e}.sim-bar .d3{background:#28c840}
+  .sim-bar .t{margin-left:8px;font-family:'IBM Plex Mono',monospace;font-size:12px;color:var(--muted)}
+  .sim-body{padding:18px 18px 34px;height:440px;overflow:hidden;font-size:13.5px;line-height:1.55}
+  .sim .row{margin:7px 0}
+  .sim .user{font-family:'IBM Plex Mono',monospace;color:var(--text)}
+  .sim .pfx{color:var(--accent);margin-right:8px}
+  .sim .tx.cmd{color:var(--accent)}
+  .sim .bot{color:var(--text)}
+  .sim .sys{color:var(--muted);font-family:'IBM Plex Mono',monospace;font-size:12.5px}
+  .sim .ok{color:var(--green);font-family:'IBM Plex Mono',monospace;font-size:12.5px}
+  .sim .link{font-family:'IBM Plex Mono',monospace;font-size:12.5px;color:var(--muted)}
+  .sim .lnk{color:var(--accent);text-decoration:underline;text-underline-offset:2px}
+  .sim .phase{color:var(--accent);font-family:'IBM Plex Mono',monospace;font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;margin-top:14px}
+  .sim .done{color:var(--text);font-weight:500}
+  .sim .opts{display:flex;flex-wrap:wrap;gap:8px;margin:5px 0 2px}
+  .sim .opt{font-family:'IBM Plex Mono',monospace;font-size:12.5px;border:1px solid var(--border);border-radius:8px;padding:5px 11px;color:var(--muted);transition:all .2s}
+  .sim .opt.sel{border-color:var(--accent);color:var(--accent);background:rgba(127,200,255,.08)}
+  .sim .teach{border-left:2px solid var(--accent-bright);background:rgba(127,200,255,.04);border-radius:0 8px 8px 0;padding:9px 13px;margin:6px 0}
+  .sim .teach .h{font-family:'IBM Plex Mono',monospace;font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent);margin-bottom:3px}
+  .sim .teach .b{color:var(--muted);font-size:13px}
+  .cur{display:inline-block;width:7px;height:14px;background:var(--accent);vertical-align:-2px;animation:blink 1.1s steps(2) infinite}
+  .sim-cap{text-align:center;color:var(--muted);font-size:12.5px;margin-top:14px}
+  .sim-cap button{font-family:'IBM Plex Mono',monospace;font-size:12.5px;color:var(--text);background:transparent;border:1px solid var(--border);border-radius:8px;padding:6px 13px;cursor:pointer;margin-left:6px}
+  .sim-cap button:hover{border-color:var(--accent)}
+  /* common questions (FAQ accordion) */
+  .faq{max-width:760px;margin:30px auto 0}
+  .faq details{border-bottom:1px solid var(--border);padding:18px 2px}
+  .faq summary{list-style:none;cursor:pointer;display:flex;justify-content:space-between;align-items:center;gap:16px;font-size:16px;font-weight:500;color:var(--text)}
+  .faq summary::-webkit-details-marker{display:none}
+  .faq .qp{color:var(--muted);font-family:'IBM Plex Mono',monospace;font-size:18px;flex:none}
+  .faq .qp::before{content:"+"} .faq details[open] .qp::before{content:"\2013"}
+  .faq p{color:var(--muted);font-size:14.5px;margin:12px 0 2px;max-width:74ch}
+  /* morph blob */
+  .morph{display:grid;grid-template-columns:1.1fr .9fr;gap:40px;align-items:center;margin-top:30px;text-align:left}
+  .morph .lead{text-align:left;margin-left:0;max-width:48ch}
+  .blobwrap{display:flex;justify-content:center;align-items:center;min-height:280px}
+  .blob{width:240px;height:240px;display:flex;align-items:center;justify-content:center;
+    background:radial-gradient(circle at 32% 28%, rgba(127,200,255,.40), rgba(0,109,221,.16) 70%);
+    border:1px solid rgba(127,200,255,.30);box-shadow:0 0 90px rgba(127,200,255,.14);
+    border-radius:42% 58% 70% 30% / 45% 45% 55% 55%;
+    animation:morph 9s ease-in-out infinite, blobspin 26s linear infinite}
+  .blob .lbl{font-family:'IBM Plex Mono',monospace;font-size:14px;color:var(--text);text-align:center;animation:blobspin 26s linear infinite reverse}
+  .blob .lbl small{display:block;color:var(--accent);font-size:11px;letter-spacing:.08em;text-transform:uppercase;margin-top:4px}
+  @keyframes morph{0%,100%{border-radius:42% 58% 70% 30% / 45% 45% 55% 55%}33%{border-radius:62% 38% 34% 66% / 58% 36% 64% 42%}66%{border-radius:34% 66% 56% 44% / 40% 62% 38% 60%}}
+  @keyframes blobspin{to{transform:rotate(360deg)}}
+  @media(prefers-reduced-motion:reduce){.blob,.blob .lbl{animation:none}}
+  @media(max-width:820px){.morph{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="badge-row">
+      <span class="badge"><i class="ico ico-bolt"></i>step-by-step <b>onboarding wizard</b></span>
+      <span class="badge"><i class="ico ico-arrow-path"></i>backed by the <b>ADLC</b></span>
+      <span class="badge"><i class="ico ico-rocket-launch"></i>harness the full power of <b>LangSmith</b></span>
+    </div>
+    <h1>What if you had the <span class="grad">world's best AI engineering team</span> in your pocket?</h1>
+    <p class="sub">The LangSmith team took everything we've learned from three years leading the AI-deployment space and put it into one skill: the first built to take your agent <b>from prototype to production</b>.</p>
+    <div class="cmdmap">
+      <div class="cmdmap-label">/productionalize-agent<span class="blink"></span> <span>— the adlc orchestrator: runs every phase in order</span></div>
+      <div class="cmdmap-inner">
+        <span class="cmdbox">/build-agent</span>
+        <span class="cmdbox">/test-agent</span>
+        <span class="cmdbox">/deploy-agent</span>
+        <span class="cmdbox">/monitor-agent</span>
+        <span class="cmdbox">/improve-agent</span>
+      </div>
+      <div class="cmdmap-note"><i class="ico ico-viewfinder-circle"></i><b>Use one or all.</b> Build from scratch or improve an agent already in production!</div>
+    </div>
+  </div>
+</header>
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">The onboarding</div>
+    <h2>Watch the wizard take you from idea to production</h2>
+    <div class="sim">
+      <div class="sim-bar"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><span class="t">productionalize-agent — terminal</span></div>
+      <div class="sim-body" id="simBody"></div>
+    </div>
+    <div class="sim-cap">▸ a sped-up run of <span class="mono">/productionalize-agent</span> <button id="simReplay">↻ replay</button></div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">The gap</div>
+    <blockquote class="bigquote">"Prototypes are easy, production is hard."<cite>— <a href="https://x.com/elonmusk/status/1389102532706848768">Elon Musk</a></cite></blockquote>
+    <div class="split">
+      <div class="panel problem">
+        <h3>Without <span class="mono">/productionalize-agent</span></h3>
+        <ul>
+          <li>No evals → suboptimal quality, cost &amp; latency (flying blind)</li>
+          <li>No tests, no CI → shipping bugs &amp; regressions</li>
+          <li>No monitoring → unexpected cost runaway, found out too late</li>
+          <li><b>A cool demo that never sees the light of day</b><i class="ico ico-face-frown frown-ico"></i></li>
+        </ul>
+      </div>
+      <div class="panel solution">
+        <h3>With <span class="mono">/productionalize-agent</span></h3>
+        <ul>
+          <li>One command boots a guided, manifest-driven wizard</li>
+          <li>TDD for agents: a dataset + evaluators you <em>trust</em></li>
+          <li>CI, online evals, alerts — surfaced, not forgotten</li>
+          <li>Traced → tested → deployed → monitored on LangSmith</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">Not just a wizard</div>
+    <h2>It teaches the craft as you ship</h2>
+    <p class="lead">We've built up best practices, dispersed across hundreds of blogs, research, and videos. This skill brings those to you and teaches too — making you the expert along the way.</p>
+    <p class="lead"><b>3 teaching modes:</b> <span class="qopt">low</span><span class="qopt">medium</span><span class="qopt">high</span></p>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">Adaptable</div>
+    <h2>Morphs around your current codebase</h2>
+    <div class="morph">
+      <div>
+        <p class="lead">Point <span class="mono">/productionalize-agent</span>, or any of the sub-skills, at <b>any codebase</b>. It researches your current setup first, then recommends the <b>minimal changes</b> to start harnessing the power of the ADLC. It adapts to you, not the other way around.</p>
+      </div>
+      <div class="blobwrap">
+        <div class="blob"><span class="lbl">your codebase<small>it forms around it</small></span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="wizard">
+  <div class="wrap">
+    <div class="eyebrow">The /productionalize-agent wizard</div>
+    <h2>Five phases, one guided experience</h2>
+    <div class="acc" style="max-width:840px;margin:34px auto 0">
+      <details class="acc-item" open>
+        <summary><span class="acc-ico"><i class="ico ico-viewfinder-circle"></i></span><span class="acc-tt"><h4>Scope</h4><div class="s">what you're building &amp; who it's for</div></span><span class="acc-plus"></span></summary>
+        <div class="acc-body qbody">
+          <div class="qrow"><b>Starting point?</b><span class="qopt">Build new</span><span class="qopt">Bring my own agent</span></div>
+          <div class="qrow"><b>Describe it</b> (natural language)</div>
+          <div class="qrow"><b>What is your goal?</b><span class="qopt">demo</span><span class="qopt">serve real users</span></div>
+          <div class="qrow"><b>Who's it for?</b><span class="qopt">Myself / team → fleet (exit early)</span><span class="qopt">Customers (external) → continue</span></div>
+          <div class="qrow"><b>Teaching level?</b><span class="qopt">low</span><span class="qopt">medium</span><span class="qopt">high</span></div>
+        </div>
+      </details>
+      <details class="acc-item">
+        <summary><span class="acc-ico"><i class="ico ico-bolt"></i></span><span class="acc-tt"><h4>Build</h4><div class="s">scaffold or instrument — until traces flow</div></span><span class="acc-plus"></span></summary>
+        <div class="acc-body qbody">
+          <div class="qrow"><b>What kind?</b><span class="qopt">Agent → deepagents</span><span class="qopt">Workflow → langgraph</span><span class="qopt">Prompt → single call</span></div>
+          <div class="qrow"><b>Model?</b><span class="qopt">choose-for-me</span><span class="qopt">I pick</span></div>
+          <div class="qrow"><b>Capabilities?</b><span class="qopt">computer use</span><span class="qopt">filesystem</span><span class="qopt">…</span></div>
+          <div class="qrow"><b>Tools?</b><span class="qopt">MCP integrations</span></div>
+          <div class="qrow"><b>Knowledge source?</b><span class="qopt">docs</span><span class="qopt">url</span><span class="qopt">generate</span><span class="qopt">none</span></div>
+        </div>
+      </details>
+      <details class="acc-item">
+        <summary><span class="acc-ico"><i class="ico ico-beaker"></i></span><span class="acc-tt"><h4>Test</h4><div class="s">a dataset + evaluators you trust</div></span><span class="acc-plus"></span></summary>
+        <div class="acc-body qbody">
+          <div class="qrow"><b>Build the dataset</b> → diverse / red-team cases</div>
+          <div class="qrow"><b>What matters?</b> → write the test cases (evals)</div>
+          <div class="qrow"><b>Score</b> → run the test-suite (experiment)</div>
+          <div class="qrow"><b>Align</b> → grade in queue → alignment % (the trust step)</div>
+          <div class="qrow"><b>Fix</b> → adjust the harness to fix issues uncovered</div>
+          <div class="qrow"><b>Optimize</b> → swap models for cheapest / best-performing</div>
+          <div class="qrow"><b>Harden</b> → eval cost + CI gate</div>
+        </div>
+      </details>
+      <details class="acc-item">
+        <summary><span class="acc-ico"><i class="ico ico-rocket-launch"></i></span><span class="acc-tt"><h4>Deploy</h4><div class="s">ship behind a CI gate</div></span><span class="acc-plus"></span></summary>
+        <div class="acc-body qbody">
+          <div class="qrow"><b>Host?</b><span class="qopt">langsmith-deployments</span><span class="qopt">own-infra</span></div>
+          <div class="qrow"><b>Auth?</b><span class="qopt">OAuth</span><span class="qopt">API key</span><span class="qopt">SSO</span><span class="qopt">none</span></div>
+          <div class="qrow"><b>Frontend?</b><span class="qopt">CopilotKit</span><span class="qopt">agent-chat-ui</span><span class="qopt">assistant-ui</span><span class="qopt">own</span><span class="qopt">none</span></div>
+        </div>
+      </details>
+      <details class="acc-item">
+        <summary><span class="acc-ico"><i class="ico ico-signal"></i></span><span class="acc-tt"><h4>Monitor</h4><div class="s">online evals + alerts on live traffic</div></span><span class="acc-plus"></span></summary>
+        <div class="acc-body qbody">
+          <div class="qrow"><b>Online evals?</b> which checks + sampling %</div>
+          <div class="qrow"><b>Alerts?</b><span class="qopt">errors</span><span class="qopt">latency</span><span class="qopt">score-drops</span><span class="qopt">cost</span></div>
+        </div>
+      </details>
+      <details class="acc-item">
+        <summary><span class="acc-ico"><i class="ico ico-arrow-path"></i></span><span class="acc-tt"><h4>Improve</h4><div class="s">close the loop</div></span><span class="acc-plus"></span></summary>
+        <div class="acc-body qbody">
+          <div class="qrow"><b>Self-improve?</b><span class="qopt">yes</span><span class="qopt">no</span></div>
+          <div class="qrow">auto-route <i class="ico ico-hand-thumb-down"></i> feedback → queue</div>
+          <div class="qrow"><b>Engine</b> link (enable in the LangSmith UI)</div>
+        </div>
+      </details>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">Inside Test</div>
+    <h2>Evals you can actually trust</h2>
+    <table class="feat">
+      <tr><th>Sub-step</th><th>What happens</th></tr>
+      <tr><td><span class="pill">dataset</span></td><td><b>Find issues</b> — red-team <em>workflow</em> (parallel agents loop until they break it); maximize sample <b>diversity</b>, not size.</td></tr>
+      <tr><td><span class="pill">evaluators</span></td><td><b>What matters to you?</b> Pick dimensions — or "show me examples and I'll tell you what's good/bad." One feedback key = one test.</td></tr>
+      <tr><td><span class="pill">score</span></td><td>Run the experiment → per-key pass/fail across every case.</td></tr>
+      <tr><td><span class="pill">align</span></td><td><b>Are the evaluators any good?</b> Grade in an annotation queue → alignment % → iterate the eval prompts (train/test split, no overfitting).</td></tr>
+      <tr><td><span class="pill">fix</span></td><td>Adjust the harness to fix any issues the suite uncovered; re-run until red→green, nothing regressed. The dataset becomes a permanent regression suite.</td></tr>
+      <tr><td><span class="pill">optimize</span></td><td>Sweep models against the trusted suite → pick the <b>cheapest / best-performing</b> that still passes (resolves "choose for me").</td></tr>
+      <tr><td><span class="pill">harden</span></td><td>Reduce eval cost; add a PR-triggered <b>CI gate</b> so quality can't silently regress.</td></tr>
+    </table>
+  </div>
+</section>
+
+<!-- hidden for now — Cross-cutting mechanics
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">How it works</div>
+    <h2>Cross-cutting mechanics</h2>
+    <div class="grid">
+      <div class="card"><div class="ic"><i class="ico ico-document-text"></i></div><h3>Manifest-driven</h3><p>A <code>.adlc.json</code> records every answer — dynamic (skips what it knows), resumable, and the build spec the sub-skills read.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-academic-cap"></i></div><h3>Teaches as it goes</h3><p>Static, vetted curriculum (+ a <span class="mono">/powerup</span>-style TUI). Each phase: a teaser with <em>Learn more · Read later · Continue</em>.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-link"></i></div><h3>Surfaces everything</h3><p>Every dataset, experiment, queue & dashboard is a clickable link — recapped in a final wrap-up index. Every "Later" is tracked.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-beaker"></i></div><h3>Red-team workflow</h3><p>Fans out parallel adversarial agents that loop until they actually break your agent — confirmed failures, not guesses.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-signal"></i></div><h3>Online + offline evals</h3><p>The same judges run on a dataset (CI) and on a sample of live traffic (monitoring), unified by feedback key.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-puzzle-piece"></i></div><h3>Bring your own agent</h3><p>deepagents native, or instrument any stack — Claude/OpenAI SDK via <code>wrap_*</code>, home-grown via <code>@traceable</code>.</p></div>
+    </div>
+  </div>
+</section>
+-->
+
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">Who it's for</div>
+    <h2>Who is this for</h2>
+    <div class="grid">
+      <div class="card"><div class="ic"><i class="ico ico-rocket-launch"></i></div><h3>Teams shipping to production</h3><p>Anyone looking to <b>productionalize faster</b> — get an agent traced → tested → deployed → monitored without stitching the whole stack together by hand.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-academic-cap"></i></div><h3>Builders enabling their org</h3><p>Teams who want to <b>empower their own teams</b>: fork it, fit it to your infra, and put everyone in the org on the same rails for shipping agents.</p></div>
+      <div class="card"><div class="ic"><i class="ico ico-puzzle-piece"></i></div><h3>The LangSmith curious</h3><p>Really, <b>anyone</b> who wants to explore and harness the full power of LangSmith for best-in-class agentic development.</p></div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="wrap">
+    <div class="eyebrow">FAQ</div>
+    <h2>Common Questions</h2>
+    <div class="faq">
+      <details open>
+        <summary>Will this work with an existing agent?<span class="qp"></span></summary>
+        <p>Yes — drop in at <b>any</b> phase. Point <span class="mono">/test-agent</span> (or any phase command) at an agent already in production; it inspects the code, framework, and existing traces, bootstraps the manifest, and hardens what's missing. You don't have to start at <span class="mono">/build-agent</span>.</p>
+      </details>
+      <details>
+        <summary>Will this force me to use LangSmith for everything?<span class="qp"></span></summary>
+        <p>It centers the <b>LangSmith stack</b> for observability, evals, deployment, and monitoring — that's the point. But it's <b>framework-neutral on the agent itself</b> (deepagents, LangGraph, a Claude/OpenAI-SDK agent, or home-grown all work), and every phase is opt-in: run one command or all six. Nothing forces a rewrite.</p>
+      </details>
+      <details>
+        <summary>Will this help me migrate to LangSmith?<span class="qp"></span></summary>
+        <p>It helps you <b>instrument your current code</b> to start getting traces into LangSmith. For a deeper migration <em>from a similar product</em>, we have a separate project — <span class="mono">/migrate-from-*</span> — built for that.</p>
+      </details>
+      <details>
+        <summary>Can I customize the wizard?<span class="qp"></span></summary>
+        <p>Yes — it's built to be <b>forked and fit to your org</b>: pin approved models, swap auth / CI / frontend defaults, tune the teaching curriculum, and drop features you don't have (Engine, fleet). Forks sync upstream for new best practices, and field-discovered fixes can PR back.</p>
+      </details>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <p>A guided skill for the Agent Development Life Cycle — proposed contribution to <a href="https://github.com/langchain-ai/langsmith-skills">langchain-ai/langsmith-skills</a>. Inspired by <a href="https://github.com/garrytan/gstack">gstack</a> &amp; <a href="https://github.com/obra/superpowers">superpowers</a>.</p>
+  </div>
+</footer>
+
+<script>
+(function(){
+  /* single-open accordion (Wizard phases) */
+  var items=[].slice.call(document.querySelectorAll('details.acc-item'));
+  items.forEach(function(d){
+    d.addEventListener('toggle',function(){
+      if(d.open) items.forEach(function(o){ if(o!==d) o.open=false; });
+    });
+  });
+})();
+</script>
+<script>
+(function(){
+  var body=document.getElementById('simBody'); if(!body) return;
+  var seq=[
+    {t:'prompt', s:'/productionalize-agent', cmd:true, d:650},
+    {t:'bot', s:"Welcome! I'll take your agent from idea → traced → tested → deployed → monitored. Here's the overview…"},
+    {t:'sys', s:'↗ opening README.html'},
+    {t:'bot', s:"First — what are you starting from?"},
+    {t:'opts', o:['Build new','Bring my own agent'], pick:0},
+    {t:'bot', s:"Describe the agent in a sentence:"},
+    {t:'prompt', s:'a banking concierge for Meridian National that helps customers with their accounts'},
+    {t:'bot', s:"Who's it for?"},
+    {t:'opts', o:['Myself / team','Customers (external)'], pick:1},
+    {t:'sys', s:'→ external users · full ADLC · target = langsmith-deployments'},
+    {t:'bot', s:"What kind of agent?"},
+    {t:'opts', o:['Agent → deepagents','Workflow → langgraph','Prompt'], pick:0},
+    {t:'sys', s:'⛭ scaffolding deepagents · tracing ON from line one'},
+    {t:'ok', s:'✓ first trace received in LangSmith'},
+    {t:'link', label:'↗ view run', url:'smith.langchain.com/o/…/r/9f2a17'},
+    {t:'phase', s:'▸ Test'},
+    {t:'bot', s:"What matters most about this agent's answers?"},
+    {t:'opts', o:['groundedness','scope','tool-safety','show me outputs'], pick:[0,1,2]},
+    {t:'sys', s:'⚙ 31 cases (covering array) · one evaluator per check'},
+    {t:'link', label:'✓ built dataset', url:'smith.langchain.com/…/datasets/adf9'},
+    {t:'bot', s:"Grade a few yourself so we can trust the judges:"},
+    {t:'sys', s:'↗ annotation queue · human vs judge → 92% alignment ✓'},
+    {t:'ok', s:'✓ red→green · cheapest passing model selected'},
+    {t:'link', label:'↗ experiment', url:'smith.langchain.com/…/compare?…b952c5'},
+    {t:'phase', s:'▸ Deploy'},
+    {t:'bot', s:"Where should it run?"},
+    {t:'opts', o:['LangSmith Deployments','My own infra'], pick:0},
+    {t:'bot', s:"Auth?"},
+    {t:'opts', o:['OAuth','API key','SSO','none'], pick:0},
+    {t:'bot', s:"Frontend?"},
+    {t:'opts', o:['CopilotKit','agent-chat-ui','assistant-ui','own'], pick:1},
+    {t:'sys', s:'⛭ shipped · PR-triggered eval gate added (.github/workflows)'},
+    {t:'link', label:'↗ deployment', url:'smith.langchain.com/o/…/studio'},
+    {t:'phase', s:'▸ Monitor'},
+    {t:'bot', s:"Which checks run on live traffic, and how much to sample?"},
+    {t:'opts', o:['groundedness','scope','tool-safety'], pick:[0,1,2]},
+    {t:'opts', o:['10%','25%','100%'], pick:0},
+    {t:'bot', s:"Alert me on…"},
+    {t:'opts', o:['errors','latency','score drops','cost'], pick:[0,1,3]},
+    {t:'sys', s:'✓ online evals @10% · alerts → Slack'},
+    {t:'link', label:'↗ monitoring dashboard', url:'smith.langchain.com/…/dashboards/projects/fdd5'},
+    {t:'phase', s:'▸ Improve'},
+    {t:'bot', s:"Auto-route 👎 feedback + failing traces back into the dataset?"},
+    {t:'opts', o:['Yes','Not now'], pick:0},
+    {t:'sys', s:'✓ automation rule live · the loop is closed'},
+    {t:'sys', s:'↗ recap: dataset · experiment · deployment · dashboard · alerts — all linked'},
+    {t:'done', s:'🎉 In production — traced, tested, deployed, monitored, improving.', d:1200}
+  ];
+  var running=false, timers=[];
+  function sleep(ms){return new Promise(function(r){timers.push(setTimeout(r,ms));});}
+  function row(cls,html){var d=document.createElement('div');d.className='row '+cls;if(html!=null)d.innerHTML=html;body.appendChild(d);body.scrollTop=body.scrollHeight;return d;}
+  async function type(node,prefix,text,rate,cls){
+    node.innerHTML=prefix+'<span class="tx '+(cls||'')+'"></span><span class="cur"></span>';
+    var tx=node.querySelector('.tx');
+    for(var i=0;i<text.length;i++){ if(!running)return; tx.textContent+=text[i]; body.scrollTop=body.scrollHeight; await sleep(rate); }
+    var c=node.querySelector('.cur'); if(c) c.remove();
+  }
+  async function run(){
+    running=false; timers.forEach(clearTimeout); timers=[]; running=true; body.innerHTML='';
+    for(var i=0;i<seq.length && running;i++){
+      var st=seq[i];
+      if(st.t==='prompt'){ await type(row('user'),'<span class="pfx">›</span> ',st.s,30,st.cmd?'cmd':''); }
+      else if(st.t==='bot'){ await type(row('bot'),'<span class="pfx">◆</span> ',st.s,11); }
+      else if(st.t==='teach'){ var d=row('teach','<div class="h">'+st.title+'</div><div class="b"></div>'); await type(d.querySelector('.b'),'',st.s,9); }
+      else if(st.t==='opts'){ var d=row('opts'); st.o.forEach(function(o){var s=document.createElement('span');s.className='opt';s.textContent=o;d.appendChild(s);}); await sleep(500); var ps=d.querySelectorAll('.opt'); var picks=Array.isArray(st.pick)?st.pick:[st.pick]; if(running) picks.forEach(function(p){ if(ps[p]) ps[p].classList.add('sel'); }); await sleep(430); }
+      else if(st.t==='sys'){ row('sys',st.s); }
+      else if(st.t==='ok'){ row('ok',st.s); }
+      else if(st.t==='link'){ row('link', st.label+' · <span class="lnk">'+st.url+'</span>'); }
+      else if(st.t==='phase'){ row('phase',st.s); }
+      else if(st.t==='done'){ row('done',st.s); }
+      if(!running) return;
+      await sleep(st.d || (st.t==='prompt'?480 : st.t==='bot'?420 : 340));
+    }
+    running=false;
+  }
+  var btn=document.getElementById('simReplay');
+  if(btn) btn.addEventListener('click',function(){ run(); });
+  var started=false;
+  if('IntersectionObserver' in window){
+    new IntersectionObserver(function(es){es.forEach(function(e){ if(e.isIntersecting && !started){ started=true; run(); } });},{threshold:.3}).observe(body);
+  } else { run(); }
+})();
+</script>
+</body>
+</html>

--- a/config/skills/productionalize-agent/SKILL.md
+++ b/config/skills/productionalize-agent/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: productionalize-agent
+description: "INVOKE THIS SKILL when the user runs /productionalize-agent or wants the full guided journey from idea to a deployed, monitored agent. The ORCHESTRATOR for the Agent Development Life Cycle (Scope → Build → Test → Deploy → Monitor → Improve): owns shared state + conventions and runs the standalone phase skills (build-agent, test-agent, deploy-agent, monitor-agent, improve-agent) in order. Each phase is ALSO a standalone drop-in command. Builds on langsmith-trace, langsmith-dataset, langsmith-evaluator."
+version: 1.0.0
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, WebFetch, Skill]
+triggers: ["build me an agent end to end", "take my agent to production", "deploy my agent", "adlc"]
+---
+
+<oneliner>
+Orchestrator for the Agent Development Life Cycle — runs the standalone phase skills (build → test → deploy → monitor → improve) in order, taking a user from an idea to a deployed, traced, self-improving agent on the LangSmith stack. Each phase also works as a drop-in command.
+</oneliner>
+
+<when_to_use>
+Activate when the user types `/productionalize-agent`, or says anything like "build me an agent end to end", "take my agent to production", "I want to make an agent for X". This is the ORCHESTRATOR — it owns shared state (`.adlc.json`) and conventions, and runs the phase skills in order. For a single phase, the user can invoke that phase's skill directly (`/build-agent`, `/test-agent`, `/deploy-agent`, `/monitor-agent`, `/improve-agent`) — they share this manifest and these conventions.
+</when_to_use>
+
+<how_this_works>
+**First-run welcome (before anything else).** Read **`${CLAUDE_SKILL_DIR}/user-state.toml`** (create it if missing) — it lives in the **skill directory, not the project**, so these preferences are **shared across every project/agent** the user works on. If it has no `first_run` key, this is a first-time user: give a short warm welcome, say in one line what `/productionalize-agent` does, **`open ${CLAUDE_SKILL_DIR}/README.html`** (the bundled overview page) so they get the full picture, then record `first_run = "<ISO-8601 now>"`. On later runs (the key is present), skip the welcome. This file holds **per-user preferences** (gitignored). Current keys: `first_run`, `teaching_mode` (see the teach-as-you-go convention), and `commit-fixes-mode` (see "Contribute fixes upstream").
+
+This is a manifest-driven wizard, not a script. On every turn:
+
+1. **Load state** — read `.adlc.json` at repo root (create it if absent, see `<manifest>`).
+2. **Print the breadcrumb** — only when entering a new phase (see `<progress_tracker>`).
+3. **Ask only what's missing** — find the next unanswered question for the current phase (see `<flow>`). NEVER ask a question whose answer is already in the manifest or derivable from `audience` (see `<defaults>`).
+4. **Record** — write each answer back to `.adlc.json` immediately.
+5. **Delegate** — for each phase, invoke its standalone phase skill (`build-agent`, `test-agent`, `deploy-agent`, `monitor-agent`, `improve-agent`; plus the reused `langsmith-*` skills — see `<delegation>`), then advance the phase pointer.
+6. **Tag** — every LangSmith resource created carries the metadata in `<tagging>`.
+
+**Standalone phases + cold entry (drop in anywhere).** Each phase skill is a valid entry point on its own — a user can drop into *any* phase, even on an agent already in production, and that phase should harden/extend it. On cold entry (no `.adlc.json`, or an existing/prod agent): **bootstrap the manifest by inspecting** — read the agent's code, its `langgraph.json`/framework, and its LangSmith traces to reconstruct what's already done; produce the build-spec table to confirm; mark earlier phases as done; then do the requested phase and **fill the gaps** (don't redo build/deploy). Prereqs missing? do the minimum needed or point to the right phase command (e.g. `/test-agent` with no traces → "instrument it first, or run `/build-agent`").
+
+The wizard is resumable: re-running `/productionalize-agent` (or any phase) reloads the manifest and continues from the first unanswered question. If `audience` changed, re-confirm the derived defaults.
+
+Golden rule: **be a guide, not an interrogator.** Ask one phase's questions at a time, in plain language, with the options as a short list. Confirm audience-derived defaults in one batch rather than asking each as a yes/no.
+
+**Scope: wire the ecosystem, not the agent's IQ.** This skill's job is to get the user's agent **traced → tested → deployed → monitored** on the LangSmith stack (driving ADLC adoption). It does NOT try to improve the agent's intrinsic quality/capabilities — that's the user's domain. Each phase's gate is an ecosystem milestone (e.g. **Build's gate = traces flowing into LangSmith**), not "is the agent good."
+
+**Pace it — one teachable beat at a time.** Within a phase, move one sub-step at a time: build the artifact, show it (open its URL / display it), confirm the user understands, *then* proceed. Do NOT bundle several artifacts into one action (e.g. dataset + evaluator + experiment, or scaffold + deploy) — each is its own beat with a checkpoint. The goal is understanding, not speed.
+
+**Teach as you go — from static content, not generated.** On ENTERING each phase, present a short teaser, then offer a card: **Learn more** (print the matching phase verbatim from `references/curriculum.json` via `scripts/teach.py --print <phase>`, or launch `scripts/teach.py` for the `/powerup`-style TUI) · **Read later** (append a `{phase, title, links:[{label,url}]}` entry to the manifest's `read_later[]` — surfaced as the **📚 Learn more** section on the progress card and in the wrap-up) · **Continue** (skip). Never write this copy yourself — it's vetted and bundled. **Teaching verbosity is a per-user preference, stored as `teaching_mode` in `${CLAUDE_SKILL_DIR}/user-state.toml`** (the skill-dir state file — shared across every agent the user builds, NOT the per-agent manifest). Resolve it on entry: if it has `teaching_mode`, honor it silently; if not, ask once (low/medium/high), then **write it to `user-state.toml`** so you never ask again (the user can change it anytime by saying "teach me more/less"). Mirror the resolved value into the manifest's `learning_level` for the progress card. Honor it: **low** → teaser only · **medium** → teaser + Learn more / Read later · **high** → full explainer + Read-more links.
+
+**Off-path lookups — ground answers in the official docs, don't improvise.** The bundled `curriculum.json` covers the happy path. When the user asks something it doesn't cover (a feature, an error, an API, a "can LangSmith do X?"), don't answer from memory — search the live docs:
+- **Prefer the LangChain docs MCP** (`docs-langchain`): a `search` tool over current LangChain / LangGraph / LangSmith docs — best retrieval, returns relevant content directly, avoids deprecated suggestions. If it isn't connected, it's a one-time add: `claude mcp add --transport http docs-langchain --scope user https://docs.langchain.com/mcp` (worth recommending in fork-and-fit setup). Reach it via ToolSearch.
+- **Fallback (universal, zero-setup):** `WebFetch` the docs index `https://docs.langchain.com/llms.txt`, find the relevant page URL, then fetch that page. Use this in headless/cron runs or whenever the MCP isn't available.
+
+Either way, surface the page as a labeled hyperlink so they can read more, and if it's worth revisiting offer **Read later** (→ `read_later[]`). This keeps answers current as our docs evolve and lets the user wander off the beaten path without leaving the flow.
+
+**Contribute fixes upstream — when the skill itself is the problem.** If the user hits a snag and it looks like a defect in THIS skill — wrong or unclear instructions, a broken `scripts/` command, a stale link, an unhandled case — rather than something specific to their agent, env, or choices, offer to raise a PR to the skill's repo with the fix. This is how field-discovered issues flow back into the shared skill (the living-best-practices loop). Gate on the per-user **`commit-fixes-mode` in `${CLAUDE_SKILL_DIR}/user-state.toml`**:
+- **unset →** ask once: **Yes** (→ set `commit-fixes-mode = "on"`) · **Never** (→ `"off"`) · **Maybe later** (→ `"after-<ISO date now+30d>"`, i.e. snooze 30 days).
+- **`on` →** durable authorization: make the fix on a branch and open the PR, just give a one-line heads-up first (what + why). Don't re-ask the preference.
+- **`off` →** never offer.
+- **`after-<date>` →** treat as `off` until that date; on or after it, ask again (refresh the snooze or set on/off from their answer).
+
+Only trigger when you're reasonably sure it's a skill bug, not a user-flow quirk — false PRs are noise. Keep each PR tight: one fix, a clear title, and a short repro of what tripped the user; never bundle unrelated changes. Let `langster-safety` enforce the git/secret/remote guardrails — don't reimplement them.
+</how_this_works>
+
+<setup>
+Environment variables (same as the other LangSmith skills):
+
+```bash
+LANGSMITH_API_KEY=lsv2_pt_...      # REQUIRED for any LangSmith resource
+LANGSMITH_ENDPOINT=...              # region/self-hosted API host — MUST match where the key was created
+LANGSMITH_PROJECT=...               # default project for traces/datasets
+LANGSMITH_WORKSPACE_ID=...          # optional, org-scoped keys
+```
+
+**LANGSMITH_ENDPOINT — customers may be on a non-default region or their own host.** API keys are region-bound; pointing at the wrong endpoint returns **403 Forbidden** (not 401), which looks like a bad key but isn't. Always confirm the customer's region/host before tracing. Map the app URL → API host:
+- US (default): app `smith.langchain.com` → `https://api.smith.langchain.com`
+- EU: app `eu.smith.langchain.com` → `https://eu.api.smith.langchain.com`
+- AWS: app `aws.smith.langchain.com` → `https://aws.api.smith.langchain.com` (note: `aws.api.`, not `api.aws.`)
+- Self-hosted/hybrid: the customer's own host — ask for it.
+
+Diagnose a 403 by hitting `<endpoint>/api/v1/sessions` with `x-api-key`; a 200 means the endpoint is right. The app URL the customer pastes (e.g. `https://aws.smith.langchain.com/o/<org-id>/settings/apikeys`) reveals their region.
+
+CLI tool (used by the phase skills):
+```bash
+curl -sSL https://raw.githubusercontent.com/langchain-ai/langsmith-cli/main/scripts/install.sh | sh
+```
+
+If `LANGSMITH_API_KEY` is missing, ask for it before any phase past Build.
+
+**Ensure the docs MCP is connected (one-time, do this on first setup).** The off-path lookups prefer the LangChain docs `search` tool. Check whether `docs-langchain` is connected (`claude mcp list`); if not, add it once: `claude mcp add --transport http docs-langchain --scope user https://docs.langchain.com/mcp`. If the add fails or MCP isn't usable in this environment (headless/cron), that's fine — off-path lookups fall back to `WebFetch` on `https://docs.langchain.com/llms.txt`.
+</setup>
+
+<progress_tracker>
+Print this one-line breadcrumb at the TOP of your message when you ENTER a new phase (not every turn). Derive state from `.adlc.json`, never from memory.
+
+```
+ADLC   ✓ Scope   ✓ Build   ▶ Test   ○ Deploy   ○ Monitor   ○ Improve
+```
+
+Glyphs: `✓` complete · `▶` current · `○` pending · `–` skipped (e.g. Deploy for a local-only agent; exclude skipped phases from "current").
+
+**Sub-steppers.** Some phases have an inner stepper, printed the same way on sub-step entry (derive the current sub-step from `.adlc.json` `test_substep`). **Test** runs the TDD red-green loop:
+
+```
+Test   ✓ Dataset   ✓ Evaluators   ✓ Score   ▶ Align evals   ○ Fix   ○ Optimize (models)   ○ Harden (cost+CI)
+```
+
+**Progress card.** After completing each phase (and each Test sub-step), **OFFER to open the progress card** — regenerate it with `scripts/render_manifest.py [.adlc.json]` (writes a self-contained `.adlc.view.html`: stepper + sub-stepper + config + named resource links + reminders) and `open .adlc.view.html` so the user sees the updated state. Offer, don't force. It *injects* the JSON into the template (a `file://` page can't fetch local JSON), so re-run it to refresh.
+</progress_tracker>
+
+<manifest>
+State lives in `.adlc.json` at the repo root. It makes the wizard dynamic (skip-known) and resumable, and it is the build spec the phase skills read.
+
+```jsonc
+{
+  "schema_version": 1,
+  "session_id": "adlc_<unix_ts>",      // also used as a LangSmith run/session id
+  "created_by": "deploy_agent_skill",
+  "phase": "scope",                    // scope|build|test|deploy|monitor|improve
+  "test_substep": null,                // find-issues|write-tests|score|align|fix-green|optimize|harden
+  "deployed": null,                    // bool — actually shipped (cloud/infra) vs local dev only
+  "alerts": null,                      // {signals:[...], setup: deferred-ui|done|none}
+  "pending_reminders": [],             // deferred ACTIONS (any "Later") → wrap-up ⏰ section
+  "read_later": [],                    // deferred topics {phase,title,links} → 📚 Learn more (card + wrap-up)
+  "answers": {
+    "starting_point": null,            // build_new | existing
+    "goal": null,                      // demo | deploy
+    "learning_level": null,            // low | medium | high — mirror of user-state.toml `teaching_mode` (for the progress card)
+    "build_type": null,                // agent | workflow | single_prompt  → derives framework
+    "interaction": null,               // conversational | headless  (agents only)
+    "description": null,               // NL "describe your agent" (Scope seed)
+    "persona": null,                   // derived persona / system-prompt summary
+    "audience": null,                  // myself | team | external   ← BRANCH: myself/team→fleet+exit, external→full ADLC
+    "target": null,                    // derived: fleet (myself/team) | langsmith-deployments (external)
+    "knowledge_source": null,          // path | url | none | generate
+    "framework": null,                 // derived from build_type: deepagents | langgraph | single-call (or inferred for BYO/existing)
+    "model": null,                     // {mode: choose-for-me|i-choose|chat, name?, resolved?: bool, cost_ceiling_usd?}
+    "capabilities": [],                // computer-use | filesystem | human-approval | memory | subagents | skills | code-exec | <middleware ids>
+    "hitl": [],                        // tool names gated behind human approval (interrupt_on), e.g. ["transfer_funds"]
+    "tools": [],                       // domain tools: hand-written python | retriever | {mcp: <server>} integrations
+    "backend": null,                   // state | store | sandbox  (deepagents backend)
+    "eval_seed": null,                 // {mode: i-test|production-traffic|synthetic, scenarios?, categories?[], n?}
+    "local_run_ready": null,           // bool — set true once `make run` (BE+FE) is verified in Build
+    "host": null,                    // langsmith-deployments | own-infra | local-only
+    "auth": null,                      // oauth | api-key | sso | none
+    "frontend": null,                  // copilotkit | assistant-ui | agent-chat-ui | streamlit | terminal | own | none
+    "hardening": null,                 // evals+ci | smoke | none
+    "monitoring": null,                // true | false
+    "ci_watches": [],                  // cost | quality | safety
+    "hitl": null,                      // true | false
+    "self_improve": null,              // true | false
+    "manage_via": null,                // code | ui
+    "success_criteria": null           // open text
+  },
+  "resources": []                      // append {type, name, url, phase} as created
+}
+```
+
+Re-run logic: load → ask only `answers` keys that are null/empty for the current phase → if `audience` changed since last run, re-confirm derived defaults.
+</manifest>
+
+<flow>
+Run the phases in order. For each, **invoke its phase skill** — the detailed steps live there; this orchestrator owns the shared conventions, manifest, defaults, breadcrumb, and wrap-up. Ask only manifest keys still null; `audience` (Scope) collapses most later questions into confirmable defaults (see `<defaults>`).
+
+**Audience branch (decided early in Scope):** `myself` / `team` → `build-agent` deploys to **fleet** and the run **EXITS EARLY** (phases 2–5 are optional, runnable later as standalone commands). `external` → continue through all 5 phases.
+
+| # | Phase skill | Purpose / gate |
+|---|---|---|
+| 1 | `build-agent` | Scope + Build → **gate: traces flowing to LangSmith** |
+| 2 | `test-agent` | dataset → evaluators → **align (trust)** → red→green (resolve `model: choose-for-me`) → CI |
+| 3 | `deploy-agent` | frontend (deployment client) + auth + ship (skip if local-only) |
+| 4 | `monitor-agent` | online evaluators @ sample rate + dashboard + alerts |
+| 5 | `improve-agent` | failing traces + 👎 feedback → queue → dataset → CI; Engine link |
+
+After each phase skill returns: ensure outputs are in `resources[]`, advance `phase`, print the breadcrumb. A user may also invoke any phase skill directly (drop-in entry) — the shared manifest keeps them coherent.
+</flow>
+
+<wrap_up>
+When the final phase completes (or the user stops early), ALWAYS print a completion recap — it's part of the experience, not optional. Derive everything from `.adlc.json`:
+
+1. **`🎉 Full ADLC walkthrough complete`** header + the final breadcrumb (phases reached marked `✓`).
+2. **One line per phase** summarizing what was produced/decided — e.g. Build → framework + "traces flowing to LangSmith" (the gate); Test → "red-team dataset → red → fixed → green"; Deploy → frontend + CI (+ whether deploy was deferred); Monitor → "N online evals @ X%". Pull these from the manifest answers/resources, don't invent.
+3. **⏰ Surface every `pending_reminders` entry** as a checklist (e.g. deferred alerts), each as a hyperlink.
+3b. **📚 Learn more** — list every `read_later[]` entry (the topics + their doc/video links the user deferred) as hyperlinks, so nothing they wanted to revisit is lost.
+4. **Recap URLs to EVERYTHING created** — read from `resources` (which accumulates a `{type, name, url}` per artifact as it's made). Render as a **`Phase | Resource | Link` markdown table**, one row per resource, each Link a **labeled markdown hyperlink** (clickable in the terminal). Cover: the agent repo/scaffold, the first trace + **project dashboard**, **dataset(s)**, **experiment(s)**, **annotation queue(s)**, **online evaluators + automation rules**, and the **deployment/Studio + frontend**. The user should leave with one clickable index of everything now live in their LangSmith account + codebase.
+
+Keep it skimmable. This recap is what the user remembers — it shows them everything now live in their LangSmith account.
+</wrap_up>
+
+<defaults>
+`audience` is the **branch + defaults switch**. **Myself / team → `target=fleet` and EXIT EARLY** (build + deploy to fleet; the production rows below mostly don't apply — they can run those phase skills later). **External → `target=langsmith-deployments`, full ADLC** with these defaults. Surface as one confirmable summary, don't ask one-by-one.
+
+| setting | fleet (myself / team) | external (langsmith-deployments) |
+|---|---|---|
+| target / host | fleet (managed) | langsmith-deployments |
+| path | Build → fleet → **exit** | full ADLC (Test→Deploy→Monitor→Improve) |
+| auth | fleet handles | oauth / api-key |
+| frontend | fleet UI | copilotkit |
+| tracing | on | on |
+| monitoring / hardening | optional (run later) | on / evals+ci |
+
+self_improve is always offered (never defaulted on).
+</defaults>
+
+<delegation>
+The orchestrator does NOT implement phase work; it invokes the standalone phase skill, passing the shared `.adlc.json` as context. Each phase skill reuses the `langsmith-*` skills internally.
+
+| phase | invoke skill | produces |
+|---|---|---|
+| Scope + Build | `build-agent` | manifest (scope answers + domain payload) → scaffold/instrument with tracing; **traces flowing** |
+| Test | `test-agent` (uses `langsmith-dataset`, `langsmith-evaluator`) | diverse dataset + aligned evaluators + experiment; red→green; CI |
+| Deploy | `deploy-agent` | deployment-client frontend + auth + ship (LangSmith Deployments/own-infra) |
+| Monitor | `monitor-agent` (uses `langsmith-trace`, `langsmith-evaluator`) | online evaluators @ sample rate + dashboard + alerts |
+| Improve | `improve-agent` | failing-trace + 👎-feedback → queue → dataset → CI loop; Engine link |
+
+**Compose with the official LangChain / Deep Agents building skills — don't reinvent framework guidance.** This suite owns the *lifecycle*; the framework "how-to-build" lives in maintained skills that stay current: **`ecosystem-primer`** (framework selection — invoke first in Build), **`deep-agents-core` / `-memory` / `-orchestration`**, **`langgraph-fundamentals` / `langgraph-cli`**, **`langchain-fundamentals` / `langchain-dependencies`** (Build), and **`managed-deep-agents`** (Deploy). Build/Deploy invoke these; this orchestrator just sequences phases.
+
+After a phase skill returns, ensure its outputs are in `resources[]`, advance `phase`, print the breadcrumb. Phase skills share these conventions (manifest, breadcrumb, teach-as-you-go, surfacing, wrap-up) — they reference this orchestrator's SKILL.md rather than redefining them.
+</delegation>
+
+<shared_assets>
+Bundled here in the orchestrator; phase skills reference them by relative path:
+- `references/curriculum.json` — static per-phase teaching (used via `scripts/teach.py`).
+- `scripts/teach.py` — `--print <phase>` / `--teaser <phase>` / interactive TUI.
+- `scripts/render_manifest.py` — renders `.adlc.json` → self-contained `.adlc.view.html` dashboard (HTML in `scripts/manifest_view_template.html`).
+- `scripts/covering_array.py` — deterministic t-wise covering-array generator for `/test-agent`'s rigorous combinatorial dataset mode (factors+constraints JSON → minimal coverage rows; self-verifies).
+From a phase skill, reference these as `../productionalize-agent/references/...` and `../productionalize-agent/scripts/...`.
+
+**Maintenance — keep the README in sync.** The public `README.html` "The wizard" section mirrors the questions the phase skills ask (Scope/Build/Test/Deploy/Monitor/Improve question flows + their option chips). If you **add, remove, rename, or re-order any wizard question or option** in a phase skill (or change an enum like `learning_level`/`eval_seed`), update the matching `qflow` rows in `README.html` in the same change so the proposal page never drifts from the actual flow. The first-run welcome opens the copy **bundled in this skill dir** (`${CLAUDE_SKILL_DIR}/README.html`) — keep it identical to the repo-root `README.html`.
+</shared_assets>
+
+<tagging>
+Every LangSmith resource (dataset, examples, evaluator, experiment, deployment, fleet agent) MUST carry:
+
+```json
+{ "created_by": "deploy_agent_skill", "adlc_session": "<session_id>", "adlc_phase": "<phase>" }
+```
+
+This enables attribution and the adoption funnel (agents created via the wizard that are still emitting traces/runs N days later).
+
+Also, whenever you create a resource (or print its URL), **append `{type, name, url, phase}` to the manifest `resources[]`** — this is the running index the wrap-up reads to recap every URL. Don't rely on memory; record the URL the moment you surface it.
+</tagging>
+
+<rules>
+- Ask one phase at a time; never dump the whole questionnaire.
+- Never ask a question already answered or derivable from `audience`.
+- Write to `.adlc.json` after every answer — it is the single source of truth, not your memory.
+- **Every AskUserQuestion is a decision brief:** lead each option with its tradeoff, put `(recommended)` on exactly one option with a one-line *why*, and name the stakes when it's high-impact. Never ask without a recommendation. Use AskUserQuestion for option selection, not free-text.
+- **Surface every LangSmith resource you create** as a **labeled markdown hyperlink** (`[Dataset](url)`, `[View trace](url)`) — NOT a raw URL. Claude Code renders GitHub-flavored markdown, so links are clickable in the terminal and far cleaner. After creating a dataset, experiment, evaluator, deployment, or trace: **`open <url>` (launch its LangSmith dashboard) AND print the labeled link, then pause and invite the user to review it before proceeding** (per *Pace it* — each artifact is a checkpoint, e.g. after the dataset is created, open it and ask them to look over the cases before any eval). Build the URL from the region host (matching `LANGSMITH_ENDPOINT` — e.g. `aws.smith.langchain.com`) + org id + resource id, e.g. `https://<host>/o/<org>/datasets/<dataset_id>`.
+- **UI-only capabilities (alerts, Engine, etc.): link, don't fake-wire.** Some LangSmith features can't be enabled via API. Surface a labeled link to the LangSmith UI, offer to defer (add to `pending_reminders` so the wrap-up recaps it as "set up later"), and never claim to have wired something you can't.
+- **All "Later"/defer choices route to ONE place: `pending_reminders[]`.** Any time the user picks "Later" on any offer (alerts, Engine, eval-cost reduction, CI, deploy, harness improvement…), append a **markdown string with an inline link** — e.g. `Set up alerts in the [LangSmith UI](<url>) — errors, latency spikes` — to the manifest's `pending_reminders[]` (the card/wrap-up render `[label](url)` as real hyperlinks, so don't paste bare URLs). The `<wrap_up>` ⏰ section surfaces every entry. This is the single deferred-work tracker — don't invent per-feature reminder logic.
+- Recommend the LangSmith-ecosystem option, but always let the user override.
+- Default tracing ON; do not deploy without evals when audience=external.
+- **Resolve outstanding commitments before wrap-up — never silently ship a default.** Notably: if `model.mode == choose-for-me` and not `model.resolved`, run the model sweep in Test (once evals are trusted) or, if the user defers, add it to `pending_reminders`. The same applies to any "decide later" the wizard promised.
+- Print the breadcrumb on phase entry only.
+</rules>
+
+<completion>
+End every phase (and the whole run) with a status:
+- **DONE** — phase gate met, with evidence (Build: a trace URL; Test: a green experiment + aligned evals; Deploy: a live frontend; etc.).
+- **DONE_WITH_CONCERNS** — met, but flag what's shaky (evals not yet aligned, deploy deferred, model not yet swept).
+- **BLOCKED** — can't proceed; state the blocker + what was tried.
+- **NEEDS_CONTEXT** — missing info/credentials; state exactly what's needed (e.g. a valid `LANGSMITH_API_KEY` for the right region).
+**Escalate after ~3 failed attempts** at the same step instead of looping — it usually means wrong layer (architecture/eval), not wrong fix.
+</completion>
+
+<voice>
+Lead with the point. Be concrete — name files, URLs, eval keys, real numbers. Tie choices to what the user gets (sees, ships, avoids). A guide talking to a builder, not a consultant pitching a client. No hype, no filler.
+</voice>
+
+<example_opening>
+When invoked with `/productionalize-agent` and no manifest yet:
+
+> ADLC   ▶ Scope   ○ Build   ○ Test   ○ Deploy   ○ Monitor   ○ Improve
+>
+> Let's get your agent onto the LangSmith stack. First:
+>
+> **Are we starting fresh, or do you have an agent already?**
+> - Build a new agent
+> - I already have one (I'll inspect it and harden what's missing)
+
+(Then delegate to `build-agent`. Use `AskUserQuestion` for option selection, not free text.)
+</example_opening>

--- a/config/skills/productionalize-agent/references/curriculum.json
+++ b/config/skills/productionalize-agent/references/curriculum.json
@@ -1,0 +1,108 @@
+{
+  "_comment": "Static teaching content for the ADLC wizard. The orchestrator shows `teaser` at each phase transition (with Learn more / Continue); `what`/`in_it`/`why` are the full explainer behind 'Learn more'. Bundled + vetted — never LLM-generated. teach.py renders these.",
+  "phases": [
+    {
+      "key": "scope",
+      "title": "Scope",
+      "teaser": "The fastest way to waste a week is to build the wrong thing. A couple of questions decide most of it.",
+      "what": "Figure out what you're really building and who it's for — before any code.",
+      "in_it": [
+        "What kind: Agent (→ deepagents) / Workflow (→ langgraph) / Prompt (→ a single model call)",
+        "Audience — the branch: myself/team → fleet & exit early; customers/external → the full ADLC",
+        "A plain-language description + where the agent's knowledge comes from"
+      ],
+      "why": "Wrong scope wastes the whole build. Audience decides the entire path — a quick fleet agent vs the full production cycle — and collapses ~half the later defaults.",
+      "links": [
+        {"label": "Deep Agents — overview", "url": "https://docs.langchain.com/oss/python/deepagents/overview"},
+        {"label": "Context engineering concepts", "url": "https://docs.langchain.com/langsmith/context-engineering-concepts"}
+      ]
+    },
+    {
+      "key": "build",
+      "title": "Build",
+      "teaser": "Time to turn your idea into something you can actually open and talk to — with observability baked in from the first line.",
+      "what": "Turn the spec into a running agent plus a UI you can actually open.",
+      "in_it": [
+        "Framework (deepagents), model, tools/capabilities, middleware, backend",
+        "Tracing wired in from day one",
+        "A build-spec sign-off table before moving on"
+      ],
+      "why": "A phase is only done when you can see it work — not when questions are answered. Tracing-from-the-start is what makes every later phase possible.",
+      "links": [
+        {"label": "Deep Agents — quickstart", "url": "https://docs.langchain.com/oss/python/deepagents/quickstart"},
+        {"label": "LangSmith tracing — quickstart", "url": "https://docs.langchain.com/langsmith/observability-quickstart"}
+      ]
+    },
+    {
+      "key": "test",
+      "title": "Test",
+      "teaser": "Any good software needs testing before release — but agents are a little special: the same input can give different outputs, so we measure behavior, not exact strings.",
+      "what": "TDD for agents — write failing cases first (red), prove they fail, then fix to green. Assert behavior, not exact output.",
+      "in_it": [
+        "Dataset: coverage-first — describe your scenarios → ~10 categories → diverse prompts per category (stratified sampling), plus real failures mined from prod traces and red-team breakers",
+        "Evaluators: 'what matters to you' → assertions, one feedback key per check",
+        "Align: validate the evaluators against your own judgment (annotation queue → alignment %) before trusting them",
+        "Experiment: run + score, then red→green; harden with eval-cost cuts + a CI gate"
+      ],
+      "analogies": [
+        {"concept": "Dataset", "like": "the cases in @pytest.mark.parametrize — the table of inputs the suite runs over (each example = one row)"},
+        {"concept": "Assertion / feedback key", "like": "one Python test, 1-to-1 — each is independently pass/failed and tracked by its key. We implement N of them as a single evaluator that loops over the example's assertions (they're data-driven), but conceptually it's one test per assertion."},
+        {"concept": "Experiment", "like": "the pytest run — every test across every case, reporting pass/fail per (test x case)"}
+      ],
+      "why": "Catches regressions, lets you compare models/prompts objectively, gates safe deploys, and the same evaluators become your online monitors later.",
+      "links": [
+        {"label": "LangSmith evaluations — video walkthrough", "url": "https://www.youtube.com/watch?v=vygFgCNR7WA&list=PLfaIDFEXuae0um8Fj0V4dHG37fGFU8Q5S"},
+        {"label": "Align LLM-judge evaluators with human feedback", "url": "https://www.langchain.com/resources/llm-as-a-judge#how-to-align-evaluators-with-human-feedback"}
+      ]
+    },
+    {
+      "key": "deploy",
+      "title": "Deploy",
+      "teaser": "An agent only creates value once people can reach it. This is where it goes from your machine to the world — safely.",
+      "what": "Put the agent where its users are.",
+      "in_it": [
+        "LangSmith Deployment (or fleet) + a frontend that is a thin deployment CLIENT",
+        "Auth",
+        "GitHub Actions CI that runs your evals on every change"
+      ],
+      "why": "A prototype that never ships generates no value (and no usage). CI keeps quality from silently regressing once people depend on it.",
+      "links": [
+        {"label": "LangSmith Deployment", "url": "https://docs.langchain.com/langsmith/deployment"},
+        {"label": "Deploy your app to cloud", "url": "https://docs.langchain.com/langsmith/deployment-quickstart"}
+      ]
+    },
+    {
+      "key": "monitor",
+      "title": "Monitor",
+      "teaser": "Offline tests can't predict everything real users will do. Monitoring is how you catch the surprises in production.",
+      "what": "Watch the agent on live traffic. Gated on TRACING (on since Build) — NOT on a cloud deploy. Dev runs, test experiments, and red-team runs all populate the dashboards; you're monitoring the moment traces flow.",
+      "in_it": [
+        "Online evaluators (the offline judges, promoted)",
+        "Dashboards + alerts",
+        "Annotation queues to calibrate judges against human labels"
+      ],
+      "why": "Offline evals can't anticipate everything. Real users surface real failure modes — and feed the next round of fixes.",
+      "links": [
+        {"label": "LangSmith Observability", "url": "https://docs.langchain.com/langsmith/observability"},
+        {"label": "Online LLM-as-judge evaluators", "url": "https://docs.langchain.com/langsmith/online-evaluations-llm-as-judge"},
+        {"label": "Alerts (Slack / email / PagerDuty / webhook)", "url": "https://docs.langchain.com/langsmith/alerts"}
+      ]
+    },
+    {
+      "key": "improve",
+      "title": "Improve",
+      "teaser": "Agents drift as models and inputs change. This is the loop that turns real failures into a steadily better agent.",
+      "what": "Close the loop so the agent gets better over time.",
+      "in_it": [
+        "Mine failing traces → add to the dataset",
+        "Optimize prompt/model, re-run evals",
+        "Repeat"
+      ],
+      "why": "Agents drift as inputs and models change. Continuous improvement, grounded in real failures, is how they stay good.",
+      "links": [
+        {"label": "LangSmith Engine", "url": "https://docs.langchain.com/langsmith/engine"},
+        {"label": "Deep Agents — going to production", "url": "https://docs.langchain.com/oss/javascript/deepagents/going-to-production"}
+      ]
+    }
+  ]
+}

--- a/config/skills/productionalize-agent/scripts/covering_array.py
+++ b/config/skills/productionalize-agent/scripts/covering_array.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Generate a t-way covering array for combinatorial test-case design.
+
+Given named factors with discrete levels (and optional forbidden combinations),
+emit a COMPACT set of rows such that every combination of levels across any t
+factors appears in at least one row (pairwise / t=2 by default). This is the
+deterministic generator behind /test-agent's "rigorous" synthetic-dataset mode:
+each row is a factor-vector; an agent then writes one concrete prompt per row,
+and the row is stored as the example's metadata so coverage is auditable and
+failures map back to factor cells.
+
+Algorithm: deterministic greedy, one row at a time (AETG-style) — seed each row
+with the most-needed uncovered t-tuple, then extend factor-by-factor choosing the
+level that covers the most still-uncovered tuples. Guarantees full t-way coverage
+(not provably minimal, but compact). No third-party deps.
+
+Usage:
+  python covering_array.py factors.json [--strength 2]
+  echo '{"factors": {...}, "constraints": [...]}' | python covering_array.py -
+
+Spec (JSON):
+  {
+    "factors": {
+      "intent":      ["balance", "transfer", "dispute", "out_of_scope"],
+      "persona":     ["novice", "expert", "hostile"],
+      "difficulty":  ["easy", "hard"],
+      "tool_needed": ["yes", "no"]
+    },
+    "constraints": [ {"intent": "out_of_scope", "tool_needed": "yes"} ]
+  }
+
+Output: JSON list of rows, each a {factor: level} dict (stderr prints the count).
+"""
+from itertools import combinations, product
+import json
+import sys
+
+
+def _violates(assignment, constraints):
+    """True if a (partial) assignment is a superset of any forbidden combo."""
+    return any(all(assignment.get(k) == v for k, v in c.items()) for c in constraints)
+
+
+def covering_array(factors, strength=2, constraints=None):
+    constraints = constraints or []
+    names = list(factors)
+    t = max(1, min(strength, len(names)))
+
+    # Every t-tuple that must be covered (skip ones already forbidden).
+    required = set()
+    for fset in combinations(names, t):
+        for levels in product(*(factors[f] for f in fset)):
+            assign = dict(zip(fset, levels))
+            if not _violates(assign, constraints):
+                required.add(tuple(sorted(assign.items())))
+
+    def covers(row):
+        return {tuple(sorted((f, row[f]) for f in fs)) for fs in combinations(names, t)}
+
+    rows, uncovered, guard = [], set(required), 0
+    while uncovered:
+        guard += 1
+        if guard > 100_000:
+            raise RuntimeError("did not converge — check for over-tight constraints")
+        row = dict(sorted(uncovered)[0])          # seed with a needed tuple
+        for f in names:
+            if f in row:
+                continue
+            assigned = [g for g in names if g in row]
+            best, best_gain = None, -1
+            for lvl in factors[f]:
+                if _violates({**row, f: lvl}, constraints):
+                    continue
+                gain = sum(
+                    tuple(sorted([(g, row[g]) for g in sub] + [(f, lvl)])) in uncovered
+                    for sub in combinations(assigned, min(t - 1, len(assigned)))
+                )
+                if gain > best_gain:
+                    best, best_gain = lvl, gain
+            if best is None:                      # constraint dead-end: any legal level
+                best = next((lvl for lvl in factors[f]
+                             if not _violates({**row, f: lvl}, constraints)), factors[f][0])
+            row[f] = best
+        uncovered -= covers(row)
+        rows.append(row)
+    return rows
+
+
+def _verify(rows, factors, strength, constraints):
+    """Assert every required t-tuple is covered by at least one row."""
+    names, t = list(factors), max(1, min(strength, len(factors)))
+    need = set()
+    for fset in combinations(names, t):
+        for levels in product(*(factors[f] for f in fset)):
+            a = dict(zip(fset, levels))
+            if not _violates(a, constraints or []):
+                need.add(tuple(sorted(a.items())))
+    have = set()
+    for r in rows:
+        for fs in combinations(names, t):
+            have.add(tuple(sorted((f, r[f]) for f in fs)))
+    missing = need - have
+    if missing:
+        raise AssertionError(f"{len(missing)} t-tuples uncovered, e.g. {sorted(missing)[:3]}")
+
+
+def main(argv):
+    strength = 2
+    if "--strength" in argv:
+        i = argv.index("--strength"); strength = int(argv[i + 1]); argv = argv[:i] + argv[i + 2:]
+    if not argv:
+        print(__doc__); return 2
+    raw = sys.stdin.read() if argv[0] == "-" else open(argv[0], encoding="utf-8").read()
+    spec = json.loads(raw)
+    factors, constraints = spec["factors"], spec.get("constraints", [])
+    rows = covering_array(factors, strength, constraints)
+    _verify(rows, factors, strength, constraints)
+    full = 1
+    for v in factors.values():
+        full *= len(v)
+    print(json.dumps(rows, indent=2))
+    print(f"# {len(rows)} rows  (t={min(strength, len(factors))}, "
+          f"vs {full} full-factorial)  coverage verified", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/config/skills/productionalize-agent/scripts/manifest_view_template.html
+++ b/config/skills/productionalize-agent/scripts/manifest_view_template.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>ADLC — agent state</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2032%2032%27%3E%3Crect%20width%3D%2732%27%20height%3D%2732%27%20rx%3D%277%27%20fill%3D%27%230D1322%27%2F%3E%3Cg%20transform%3D%27translate%284%2C4%29%27%20fill%3D%27none%27%20stroke%3D%27%237FC8FF%27%20stroke-width%3D%271.8%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20d%3D%27M16.023%209.348h4.992v-.001M2.985%2019.644v-4.992m0%200h4.992m-4.993%200%203.181%203.183a8.25%208.25%200%200%200%2013.803-3.7M4.031%209.865a8.25%208.25%200%200%201%2013.803-3.7l3.181%203.182m0-4.991v4.99%27%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=IBM+Plex+Mono:wght@300;400;500&display=swap" rel="stylesheet"/>
+<style>
+:root{--bg:#030710;--bg-2:#0D1322;--card:#0D1322;--card-2:#161F34;--border:rgba(255,255,255,.08);--text:#F2FAFF;--muted:rgba(255,255,255,.6);--accent:#7FC8FF;--green:#8CDB9B;--amber:#FBB0A5;--pend:#2F4B68}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:Inter,system-ui,sans-serif;font-weight:300;background:var(--bg);color:var(--text);line-height:1.55;padding:40px 20px;-webkit-font-smoothing:antialiased}
+.wrap{max-width:920px;margin:0 auto}
+h1{font-size:24px;font-weight:300;letter-spacing:-.02em}
+.sub{color:var(--muted);font-size:14px;margin-top:4px}
+.eyebrow{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--accent);font-weight:500;margin:30px 0 12px}
+.mono{font-family:'IBM Plex Mono',ui-monospace,monospace}
+/* stepper */
+.stepper{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}
+.step{flex:1 1 0;min-width:120px;background:var(--card);border:1px solid var(--border);border-radius:10px;padding:12px 14px}
+.step .glyph{font-size:13px;font-weight:600}
+.step .name{font-size:14px;font-weight:500;margin-top:2px}
+.step.done{border-color:rgba(140,219,155,.4)} .step.done .glyph{color:var(--green)}
+.step.current{border-color:rgba(127,200,255,.6);box-shadow:0 0 0 1px rgba(127,200,255,.25) inset} .step.current .glyph{color:var(--accent)}
+.step.pending .glyph,.step.pending .name{color:var(--pend)}
+.substep{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
+.chip{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:12px;border:1px solid var(--border);border-radius:999px;padding:4px 11px;color:var(--muted)}
+.chip.done{color:var(--green);border-color:rgba(140,219,155,.35)} .chip.current{color:var(--accent);border-color:rgba(127,200,255,.5)}
+/* cards */
+.card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:18px 20px;margin-top:12px}
+.kv{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px 22px}
+.kv .k{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+.kv .v{font-size:14px;font-weight:500}
+table{width:100%;border-collapse:collapse;font-size:13.5px}
+th{text-align:left;font-family:'IBM Plex Mono',ui-monospace,monospace;color:var(--accent);font-size:11px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;padding:8px 10px;border-bottom:1px solid var(--border)}
+td{padding:9px 10px;border-bottom:1px solid var(--border);color:var(--muted);vertical-align:top}
+td b{color:var(--text);font-weight:500}
+a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
+.list li{list-style:none;padding:7px 0 7px 22px;position:relative;color:var(--muted);font-size:14px}
+.list li::before{content:"";position:absolute;left:3px;top:13px;width:5px;height:5px;border-radius:50%;background:var(--accent)}
+.lm-ph{color:var(--accent);font-size:11px;text-transform:uppercase;letter-spacing:.06em}
+.lm-links{margin-top:3px;font-size:13px}
+.runcmd{font-family:'IBM Plex Mono',ui-monospace,monospace;color:var(--accent);font-size:15px}
+.runsub{color:var(--muted);font-size:13px;margin-left:12px}
+.rname{color:var(--muted);font-size:12px;margin-top:2px}
+.rstat{color:var(--muted)}
+.empty{color:var(--pend);font-size:13px}
+
+/* Heroicons v2.1.5 (CSS mask) */
+.ico{display:inline-block;width:1em;height:1em;vertical-align:-0.15em;background:currentColor;-webkit-mask:var(--i) center/contain no-repeat;mask:var(--i) center/contain no-repeat}
+.ico-bolt{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22m3.75%2013.5%2010.5-11.25L12%2010.5h8.25L9.75%2021.75%2012%2013.5H3.75Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-arrow-path{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M16.023%209.348h4.992v-.001M2.985%2019.644v-4.992m0%200h4.992m-4.993%200%203.181%203.183a8.25%208.25%200%200%200%2013.803-3.7M4.031%209.865a8.25%208.25%200%200%201%2013.803-3.7l3.181%203.182m0-4.991v4.99%22%2F%3E%3C%2Fsvg%3E")}
+.ico-rocket-launch{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M15.59%2014.37a6%206%200%200%201-5.84%207.38v-4.8m5.84-2.58a14.98%2014.98%200%200%200%206.16-12.12A14.98%2014.98%200%200%200%209.631%208.41m5.96%205.96a14.926%2014.926%200%200%201-5.841%202.58m-.119-8.54a6%206%200%200%200-7.381%205.84h4.8m2.581-5.84a14.927%2014.927%200%200%200-2.58%205.84m2.699%202.7c-.103.021-.207.041-.311.06a15.09%2015.09%200%200%201-2.448-2.448%2014.9%2014.9%200%200%201%20.06-.312m-2.24%202.39a4.493%204.493%200%200%200-1.757%204.306%204.493%204.493%200%200%200%204.306-1.758M16.5%209a1.5%201.5%200%201%201-3%200%201.5%201.5%200%200%201%203%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-viewfinder-circle{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M7.5%203.75H6A2.25%202.25%200%200%200%203.75%206v1.5M16.5%203.75H18A2.25%202.25%200%200%201%2020.25%206v1.5m0%209V18A2.25%202.25%200%200%201%2018%2020.25h-1.5m-9%200H6A2.25%202.25%200%200%201%203.75%2018v-1.5M15%2012a3%203%200%201%201-6%200%203%203%200%200%201%206%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-face-frown{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M15.182%2016.318A4.486%204.486%200%200%200%2012.016%2015a4.486%204.486%200%200%200-3.198%201.318M21%2012a9%209%200%201%201-18%200%209%209%200%200%201%2018%200ZM9.75%209.75c0%20.414-.168.75-.375.75S9%2010.164%209%209.75%209.168%209%209.375%209s.375.336.375.75Zm-.375%200h.008v.015h-.008V9.75Zm5.625%200c0%20.414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375%200h.008v.015h-.008V9.75Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-document-text{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M19.5%2014.25v-2.625a3.375%203.375%200%200%200-3.375-3.375h-1.5A1.125%201.125%200%200%201%2013.5%207.125v-1.5a3.375%203.375%200%200%200-3.375-3.375H8.25m0%2012.75h7.5m-7.5%203H12M10.5%202.25H5.625c-.621%200-1.125.504-1.125%201.125v17.25c0%20.621.504%201.125%201.125%201.125h12.75c.621%200%201.125-.504%201.125-1.125V11.25a9%209%200%200%200-9-9Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-academic-cap{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M4.26%2010.147a60.438%2060.438%200%200%200-.491%206.347A48.62%2048.62%200%200%201%2012%2020.904a48.62%2048.62%200%200%201%208.232-4.41%2060.46%2060.46%200%200%200-.491-6.347m-15.482%200a50.636%2050.636%200%200%200-2.658-.813A59.906%2059.906%200%200%201%2012%203.493a59.903%2059.903%200%200%201%2010.399%205.84c-.896.248-1.783.52-2.658.814m-15.482%200A50.717%2050.717%200%200%201%2012%2013.489a50.702%2050.702%200%200%201%207.74-3.342M6.75%2015a.75.75%200%201%200%200-1.5.75.75%200%200%200%200%201.5Zm0%200v-3.675A55.378%2055.378%200%200%201%2012%208.443m-7.007%2011.55A5.981%205.981%200%200%200%206.75%2015.75v-1.5%22%2F%3E%3C%2Fsvg%3E")}
+.ico-link{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M13.19%208.688a4.5%204.5%200%200%201%201.242%207.244l-4.5%204.5a4.5%204.5%200%200%201-6.364-6.364l1.757-1.757m13.35-.622%201.757-1.757a4.5%204.5%200%200%200-6.364-6.364l-4.5%204.5a4.5%204.5%200%200%200%201.242%207.244%22%2F%3E%3C%2Fsvg%3E")}
+.ico-beaker{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M9.75%203.104v5.714a2.25%202.25%200%200%201-.659%201.591L5%2014.5M9.75%203.104c-.251.023-.501.05-.75.082m.75-.082a24.301%2024.301%200%200%201%204.5%200m0%200v5.714c0%20.597.237%201.17.659%201.591L19.8%2015.3M14.25%203.104c.251.023.501.05.75.082M19.8%2015.3l-1.57.393A9.065%209.065%200%200%201%2012%2015a9.065%209.065%200%200%200-6.23-.693L5%2014.5m14.8.8%201.402%201.402c1.232%201.232.65%203.318-1.067%203.611A48.309%2048.309%200%200%201%2012%2021c-2.773%200-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5%2014.5%22%2F%3E%3C%2Fsvg%3E")}
+.ico-signal{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M9.348%2014.652a3.75%203.75%200%200%201%200-5.304m5.304%200a3.75%203.75%200%200%201%200%205.304m-7.425%202.121a6.75%206.75%200%200%201%200-9.546m9.546%200a6.75%206.75%200%200%201%200%209.546M5.106%2018.894c-3.808-3.807-3.808-9.98%200-13.788m13.788%200c3.808%203.807%203.808%209.98%200%2013.788M12%2012h.008v.008H12V12Zm.375%200a.375.375%200%201%201-.75%200%20.375.375%200%200%201%20.75%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-puzzle-piece{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M14.25%206.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003%200-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25%201.875c0%20.369.128.713.349%201.003.215.283.401.604.401.959v0a.64.64%200%200%201-.657.643%2048.39%2048.39%200%200%201-4.163-.3c.186%201.613.293%203.25.315%204.907a.656.656%200%200%201-.658.663v0c-.355%200-.676-.186-.959-.401a1.647%201.647%200%200%200-1.003-.349c-1.036%200-1.875%201.007-1.875%202.25s.84%202.25%201.875%202.25c.369%200%20.713-.128%201.003-.349.283-.215.604-.401.959-.401v0c.31%200%20.555.26.532.57a48.039%2048.039%200%200%201-.642%205.056c1.518.19%203.058.309%204.616.354a.64.64%200%200%200%20.657-.643v0c0-.355-.186-.676-.401-.959a1.647%201.647%200%200%201-.349-1.003c0-1.035%201.008-1.875%202.25-1.875%201.243%200%202.25.84%202.25%201.875%200%20.369-.128.713-.349%201.003-.215.283-.4.604-.4.959v0c0%20.333.277.599.61.58a48.1%2048.1%200%200%200%205.427-.63%2048.05%2048.05%200%200%200%20.582-4.717.532.532%200%200%200-.533-.57v0c-.355%200-.676.186-.959.401-.29.221-.634.349-1.003.349-1.035%200-1.875-1.007-1.875-2.25s.84-2.25%201.875-2.25c.37%200%20.713.128%201.003.349.283.215.604.401.96.401v0a.656.656%200%200%200%20.658-.663%2048.422%2048.422%200%200%200-.37-5.36c-1.886.342-3.81.574-5.766.689a.578.578%200%200%201-.61-.58v0Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-hand-thumb-down{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M7.498%2015.25H4.372c-1.026%200-1.945-.694-2.054-1.715a12.137%2012.137%200%200%201-.068-1.285c0-2.848.992-5.464%202.649-7.521C5.287%204.247%205.886%204%206.504%204h4.016a4.5%204.5%200%200%201%201.423.23l3.114%201.04a4.5%204.5%200%200%200%201.423.23h1.294M7.498%2015.25c.618%200%20.991.724.725%201.282A7.471%207.471%200%200%200%207.5%2019.75%202.25%202.25%200%200%200%209.75%2022a.75.75%200%200%200%20.75-.75v-.633c0-.573.11-1.14.322-1.672.304-.76.93-1.33%201.653-1.715a9.04%209.04%200%200%200%202.86-2.4c.498-.634%201.226-1.08%202.032-1.08h.384m-10.253%201.5H9.7m8.075-9.75c.01.05.027.1.05.148.593%201.2.925%202.55.925%203.977%200%201.487-.36%202.89-.999%204.125m.023-8.25c-.076-.365.183-.75.575-.75h.908c.889%200%201.713.518%201.972%201.368.339%201.11.521%202.287.521%203.507%200%201.553-.295%203.036-.831%204.398-.306.774-1.086%201.227-1.918%201.227h-1.053c-.472%200-.745-.556-.5-.96a8.95%208.95%200%200%200%20.303-.54%22%2F%3E%3C%2Fsvg%3E")}
+.ico-clock{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M12%206v6h4.5m4.5%200a9%209%200%201%201-18%200%209%209%200%200%201%2018%200Z%22%2F%3E%3C%2Fsvg%3E")}
+.ico-book-open{--i:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%23000%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%3E%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M12%206.042A8.967%208.967%200%200%200%206%203.75c-1.052%200-2.062.18-3%20.512v14.25A8.987%208.987%200%200%201%206%2018c2.305%200%204.408.867%206%202.292m0-14.25a8.966%208.966%200%200%201%206-2.292c1.052%200%202.062.18%203%20.512v14.25A8.987%208.987%200%200%200%2018%2018a8.967%208.967%200%200%200-6%202.292m0-14.25v14.25%22%2F%3E%3C%2Fsvg%3E")}
+.eyebrow .ico{color:var(--accent);margin-right:6px}
+</style></head><body><div class="wrap" id="app"></div>
+<script>
+const MANIFEST = __MANIFEST_JSON__;
+const PHASES = ["scope","build","test","deploy","monitor","improve"];
+const TSUB = [["find-issues","Dataset"],["write-tests","Evaluators"],["score","Score"],["align","Align evals"],["fix-green","Fix"],["optimize","Optimize"],["harden","Harden"]];
+const el=(h)=>{const t=document.createElement("template");t.innerHTML=h.trim();return t.content.firstChild;};
+const esc=(s)=>String(s).replace(/[&<>]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+const linkify=(s)=>{const bare=(t)=>esc(t).replace(/(https?:\/\/[^\s]+)/g,'<a href="$1">$1</a>');let out="",last=0,m;const re=/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;while((m=re.exec(s))){out+=bare(s.slice(last,m.index))+`<a href="${esc(m[2])}">${esc(m[1])}</a>`;last=m.index+m[0].length;}return out+bare(s.slice(last));};
+const app=document.getElementById("app");
+const a=MANIFEST.answers||{};
+const phaseIdx=PHASES.indexOf(MANIFEST.phase);
+
+app.appendChild(el(`<div><h1>${esc(a.description||"Agent")}</h1>
+  <div class="sub mono">phase: ${esc(MANIFEST.phase||"?")} · session ${esc(MANIFEST.session_id||"")} ${MANIFEST.deployed===false?"· not deployed":""}</div></div>`));
+
+// ADLC stepper
+app.appendChild(el('<div class="eyebrow">ADLC</div>'));
+const stp=el('<div class="stepper"></div>');
+PHASES.forEach((p,i)=>{const st=i<phaseIdx?"done":i===phaseIdx?"current":"pending";
+  const g=i<phaseIdx?"✓":i===phaseIdx?"▶":"○";
+  stp.appendChild(el(`<div class="step ${st}"><div class="glyph">${g}</div><div class="name">${p[0].toUpperCase()+p.slice(1)}</div></div>`));});
+app.appendChild(stp);
+
+// Test sub-stepper
+if(MANIFEST.test_substep){const cur=MANIFEST.test_substep;const ci=TSUB.findIndex(s=>s[0]===cur);
+  const sub=el('<div class="substep"></div>');
+  TSUB.forEach((s,i)=>{const done=cur==="done"||i<ci;const isc=i===ci;
+    sub.appendChild(el(`<span class="chip ${done?"done":isc?"current":""}">${done?"✓ ":isc?"▶ ":""}${s[1]}</span>`));});
+  app.appendChild(el('<div class="eyebrow">Test sub-steps</div>'));app.appendChild(sub);}
+
+// Answers
+app.appendChild(el('<div class="eyebrow">Configuration</div>'));
+const HIDE=new Set(["build_delivers","description","manage_via","backend"]);
+const VLABEL={audience:{external:"external users",myself:"myself",team:"team"}};
+const fmt=(k,v)=>v==null?'<span class="empty">—</span>':(VLABEL[k]&&VLABEL[k][v])?esc(VLABEL[k][v]):Array.isArray(v)?v.map(esc).join(", "):typeof v==="object"?esc(JSON.stringify(v)):esc(v);
+const card=el('<div class="card"><div class="kv"></div></div>');const kv=card.querySelector(".kv");
+Object.entries(a).filter(([k])=>!HIDE.has(k)).forEach(([k,v])=>kv.appendChild(el(`<div><div class="k">${esc(k.replace(/_/g," "))}</div><div class="v">${fmt(k,v)}</div></div>`)));
+app.appendChild(card);
+
+// How to run
+app.appendChild(el('<div class="eyebrow">How to run</div>'));
+app.appendChild(el(a.local_run_ready
+  ? '<div class="card"><span class="runcmd">make run</span><span class="runsub">starts the backend + frontend locally</span></div>'
+  : '<div class="card empty">Not set up yet</div>'));
+
+// Resources
+const res=(MANIFEST.resources||[]).slice().sort((a,b)=>{const o=p=>{const i=PHASES.indexOf(p);return i<0?99:i};return o(a.phase)-o(b.phase);});
+app.appendChild(el('<div class="eyebrow">Resources created</div>'));
+if(res.length){const t=el('<div class="card"><table><thead><tr><th>Phase</th><th>Resource</th></tr></thead><tbody></tbody></table></div>');
+  const tb=t.querySelector("tbody");
+  const LL={project_dashboard:"LangSmith Monitoring",online_evaluators:"LangSmith Online Evals",dataset:"LangSmith Dataset",experiment:"LangSmith Experiment",annotation_queue:"LangSmith Annotation Queue",automation_rule:"LangSmith Automation Rule",alerts:"LangSmith Alerts",frontend:"Open app"};
+  res.forEach(r=>{const url=r.url||"";const isUrl=/^https?:/.test(url);
+    const tlabel=LL[r.type]||r.type||"resource";
+    const status=r.status?` <span class="mono rstat">(${esc(r.status)})</span>`:"";
+    const name=r.name?`<div class="rname">${esc(r.name)}</div>`:"";
+    let cell;
+    if(isUrl){cell=`<a href="${esc(url)}">${esc(tlabel)} →</a>${status}${name}`;}
+    else if(url){cell=`<b>${esc(r.name||tlabel)}</b>${status}<div class="rname mono">${esc(url)}</div>`;}
+    else{cell=`<b>${esc(r.name||tlabel)}</b>${status}`;}
+    tb.appendChild(el(`<tr><td>${esc(r.phase||"")}</td><td>${cell}</td></tr>`));});
+  app.appendChild(t);}else app.appendChild(el('<div class="card empty">none yet</div>'));
+
+// Reminders + read later
+const rem=MANIFEST.pending_reminders||[];const rd=MANIFEST.read_later||[];
+if(rem.length){app.appendChild(el('<div class="eyebrow"><i class="ico ico-clock"></i>Deferred reminders</div>'));
+  const u=el('<ul class="list rem card"></ul>');rem.forEach(x=>u.appendChild(el(`<li>${linkify(typeof x==="string"?x:JSON.stringify(x))}</li>`)));app.appendChild(u);}
+if(rd.length){app.appendChild(el('<div class="eyebrow"><i class="ico ico-book-open"></i>Learn more</div>'));
+  const u=el('<ul class="list read card"></ul>');
+  rd.forEach(x=>{
+    if(typeof x==="string"){u.appendChild(el(`<li>${linkify(x)}</li>`));return;}
+    const ph=x.phase?`<span class="mono lm-ph">${esc(x.phase)}</span> · `:"";
+    const ti=esc(x.title||x.topic||"Saved to learn more");
+    const ls=(x.links||(x.url?[x.url]:[])).map(l=>{const url=typeof l==="string"?l:(l.url||"");const lab=typeof l==="string"?l:(l.label||l.url||"");return url?`<a href="${esc(url)}">${esc(lab)}</a>`:"";}).filter(Boolean).join(" · ");
+    u.appendChild(el(`<li>${ph}<b>${ti}</b>${ls?`<div class="lm-links">${ls}</div>`:""}</li>`));
+  });
+  app.appendChild(u);}
+</script></body></html>

--- a/config/skills/productionalize-agent/scripts/render_manifest.py
+++ b/config/skills/productionalize-agent/scripts/render_manifest.py
@@ -1,0 +1,34 @@
+"""Render .adlc.json as a self-contained HTML dashboard.
+
+A double-clicked file:// HTML can't fetch a local JSON (browser security), so we
+*inject* the manifest into the template (manifest_view_template.html) and write a
+standalone viewable file.
+
+Usage:
+  python render_manifest.py [path/to/.adlc.json]   # default: ./.adlc.json
+  -> writes <manifest_dir>/.adlc.view.html
+"""
+
+import json
+import sys
+from pathlib import Path
+
+TEMPLATE = Path(__file__).with_name("manifest_view_template.html")
+
+
+def main(argv) -> int:
+    src = Path(argv[0]) if argv else Path(".adlc.json")
+    if not src.exists():
+        print(f"manifest not found: {src}", file=sys.stderr)
+        return 1
+    html = TEMPLATE.read_text(encoding="utf-8").replace(
+        "__MANIFEST_JSON__", json.dumps(json.loads(src.read_text(encoding="utf-8")))
+    )
+    out = src.parent / ".adlc.view.html"
+    out.write_text(html, encoding="utf-8")
+    print(f"wrote {out}  (open it in a browser)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/config/skills/productionalize-agent/scripts/teach.py
+++ b/config/skills/productionalize-agent/scripts/teach.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""ADLC wizard — phase teaching menu.
+
+Static content lives in ../references/curriculum.json (no LLM generation).
+
+Usage:
+  teach.py                 # interactive TUI (like /powerup): arrows + enter, q to quit
+  teach.py --print <phase> # print one phase's explainer (non-interactive; for the orchestrator)
+  teach.py --list          # list phase keys
+"""
+import json
+import sys
+from pathlib import Path
+
+CURRICULUM = Path(__file__).resolve().parent.parent / "references" / "curriculum.json"
+
+
+def load():
+    return json.loads(CURRICULUM.read_text(encoding="utf-8"))["phases"]
+
+
+def render_text(p: dict) -> str:
+    lines = [f"  {p['title']} — what this stage is", "", f"  {p['what']}", "", "  What's in it:"]
+    lines += [f"    • {x}" for x in p["in_it"]]
+    lines += ["", "  Why it matters:", f"    {p['why']}"]
+    if p.get("analogies"):
+        lines += ["", "  Like traditional testing:"]
+        lines += [f"    • {a['concept']} ≈ {a['like']}" for a in p["analogies"]]
+    if p.get("links"):
+        lines += ["", "  Learn more:"]
+        lines += [f"    → {l['label']}: {l['url']}" for l in p["links"]]
+    return "\n".join(lines)
+
+
+def cmd_print(key: str) -> int:
+    for p in load():
+        if p["key"] == key:
+            print(render_text(p))
+            return 0
+    print(f"unknown phase: {key} (use --list)", file=sys.stderr)
+    return 1
+
+
+def cmd_teaser(key: str) -> int:
+    for p in load():
+        if p["key"] == key:
+            print(p["teaser"])
+            return 0
+    print(f"unknown phase: {key} (use --list)", file=sys.stderr)
+    return 1
+
+
+def cmd_list() -> int:
+    print(" ".join(p["key"] for p in load()))
+    return 0
+
+
+def tui() -> int:
+    import curses
+
+    phases = load()
+
+    def app(stdscr):
+        curses.curs_set(0)
+        curses.use_default_colors()
+        for i in range(1, 7):
+            curses.init_pair(i, i, -1)
+        CYAN, GREEN, YELLOW, GREY = 6, 2, 3, 0
+        idx, detail = 0, False
+
+        def breadcrumb(win, row):
+            win.addstr(row, 2, "ADLC  ", curses.A_BOLD)
+            for i, p in enumerate(phases):
+                mark = "▶" if i == idx else "○"
+                attr = curses.color_pair(CYAN) | curses.A_BOLD if i == idx else curses.A_DIM
+                win.addstr(f"{mark} {p['title']}  ", attr)
+
+        while True:
+            stdscr.erase()
+            h, w = stdscr.getmaxyx()
+            breadcrumb(stdscr, 0)
+            stdscr.addstr(1, 2, "─" * (w - 4), curses.A_DIM)
+            if not detail:
+                stdscr.addstr(3, 2, "Pick a stage to learn about it:", curses.A_BOLD)
+                for i, p in enumerate(phases):
+                    sel = i == idx
+                    prefix = "  ❯ " if sel else "    "
+                    attr = curses.color_pair(GREEN) | curses.A_BOLD if sel else curses.A_NORMAL
+                    stdscr.addstr(5 + i, 2, f"{prefix}{p['title']:<10} {p['what']}"[: w - 4], attr)
+                stdscr.addstr(h - 2, 2, "↑/↓ move    enter view   q quit", curses.A_DIM)
+            else:
+                p = phases[idx]
+                stdscr.addstr(3, 2, p["title"], curses.color_pair(CYAN) | curses.A_BOLD)
+                r = 5
+                for line in render_text(p).splitlines():
+                    if r >= h - 2:
+                        break
+                    stdscr.addstr(r, 2, line[: w - 4])
+                    r += 1
+                stdscr.addstr(h - 2, 2, "←/esc back   q quit", curses.A_DIM)
+            stdscr.refresh()
+
+            k = stdscr.getch()
+            if k in (ord("q"), ord("Q")):
+                return
+            if not detail:
+                if k in (curses.KEY_DOWN, ord("j")):
+                    idx = (idx + 1) % len(phases)
+                elif k in (curses.KEY_UP, ord("k")):
+                    idx = (idx - 1) % len(phases)
+                elif k in (curses.KEY_ENTER, 10, 13, curses.KEY_RIGHT):
+                    detail = True
+            else:
+                if k in (27, curses.KEY_LEFT, ord("h")):
+                    detail = False
+
+    try:
+        curses.wrapper(app)
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+def main(argv) -> int:
+    if not argv:
+        return tui()
+    if argv[0] == "--list":
+        return cmd_list()
+    if argv[0] == "--print" and len(argv) > 1:
+        return cmd_print(argv[1])
+    if argv[0] == "--teaser" and len(argv) > 1:
+        return cmd_teaser(argv[1])
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/config/skills/test-agent/SKILL.md
+++ b/config/skills/test-agent/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: test-agent
+description: "INVOKE when the user runs /test-agent, or wants to evaluate / add evals / test / harden the quality of an agent. The Test phase of the ADLC — works standalone or as a step of /productionalize-agent. Builds an eval suite you TRUST, then red→greens the agent. Uses langsmith-dataset + langsmith-evaluator."
+version: 1.0.0
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion, Agent, WebFetch]
+triggers: ["test my agent", "add evals", "evaluate my agent", "red-team my agent"]
+---
+
+<oneliner>
+Build a dataset + evaluators you trust (align them to your judgment), then red→green the agent against them. TDD for agents.
+</oneliner>
+
+<entry>
+Standalone drop-in — great for hardening an existing/in-prod agent. On entry:
+1. Load `.adlc.json`. If absent, bootstrap by inspecting the agent + traces (build-spec table) and mark Build done.
+2. **Prereq: a traced agent.** If no traces exist, instrument it first (point to `/build-agent`) — you can't test what you can't observe.
+3. Follow the SHARED conventions in `../productionalize-agent/SKILL.md`. Teaching: `../productionalize-agent/scripts/teach.py --print test`. Print the Test sub-stepper on each sub-step; update `test_substep`; pace one beat at a time.
+</entry>
+
+<prereqs>
+A traced agent (runs landing in a LangSmith project) and `LANGSMITH_API_KEY`/`LANGSMITH_ENDPOINT`.
+</prereqs>
+
+<flow>
+**Iron Law — trust the evaluators before you trust the scores.** An unaligned eval is worse than no eval; align to human judgment first.
+
+Build an eval suite **you trust**, then use it to red→green. Paced sub-steps:
+
+**1. Find issues → build the dataset** (`find-issues`). The dataset is your suite of test cases.
+- **Dataset?** synthetic · **production traffic** · I test — pick by what's available:
+  - **I test (provided).** They hand you examples, or drive the agent themselves and tell you what's good/bad → build cases from that.
+  - **Production traffic (existing / in-prod agent) → PREFER this.** Mine actual production traces for real failures instead of inventing them: **fan out N *cheap* subagents (a Workflow) that PARTITION the trace set** — each scans its slice, flags the traces with issues and names the issue — then build the dataset from those flagged real traces (each → a case + assertion). Real failures beat synthetic ones.
+  - **New agent / little traffic → synthetic.** Use the **coverage-first generation** procedure below (positives + breakers), then harden with the red-team loop.
+  - **Demo seeds present?** If `.adlc.json` has `demo_seeds` (planted by `/build-agent` for `goal=demo`), run the red-team **blind** first, THEN cross-check that each seed was surfaced — call out any the red-team missed, and flag any *extra* real issues it found (those are the win).
+  - A dataset where everything passes proves nothing.
+- **Knowledge-grounded seeds (reverse-RAG) — PREFER when the agent has a `knowledge_source` / retriever / RAG.** Don't invent queries in a vacuum; seed them from the agent's *actual* corpus so cases are grounded **and** diverse: **①** partition the KB and fan out cheap subagents over the chunks/docs; **②** each extracts key facts from its slice; **③** for each fact, generate realistic user queries (persona-driven) that the fact answers — "running RAG backwards"; **④** keep the source chunk as the case's **expected grounding / citation** — a free oracle for the groundedness evaluator in `write-tests`. Grounded, diverse seeds → a grounded, diverse dataset. **Combine with the coverage design below for even more diversity:** cross each grounded seed with the other factors (persona × difficulty × `tool` × adversarial…) via the covering array — the KB topic/doc becomes a `topic` factor, so cases are grounded **and** combinatorially diverse. (Self-Instruct "seed collection"; Ragas-style KB testset generation.)
+- **Coverage-first synthetic generation — one design, grounded in experimental design** (run when `synthetic`, or to top up sparse cells on any path):
+  - **Ask (open-ended):** *"Describe the kinds of scenarios your agent is expected to handle — the more the better."* Combine with what's known (`description`, `persona`, `capabilities`, `tools`).
+  - **① Factors & levels.** Induce a taxonomy of **~10 scenario categories** (intents / use-cases) → that's your first, multi-level factor (`category`). Then add the other dimensions that drive behavior as factors: persona, difficulty, in-/out-of-scope, **`tool` — one level per tool the agent actually has (work *backwards from the manifest's `tools`/`capabilities`* to write realistic queries that would invoke each tool), plus `none` and `multi`**, turns, ambiguity, locale, length, adversarial. (Categories aren't a separate method — they're just one factor in the design.)
+  - **② Covering array.** Generate a **t-wise covering array** over those factors with **`../productionalize-agent/scripts/covering_array.py`** (deterministic greedy IPOG/AETG; constraint-aware; self-verifies; t=2 pairwise default, t=3 for higher assurance) — a compact balanced table (e.g. 7 factors → ~13 rows vs 384 full) where every category appears AND every category×persona, category×difficulty… pair is covered. **Lite path:** run with *only* the `category` factor and it degenerates to ~N diverse prompts per category (the simple taxonomy fan-out).
+  - **③ Generate + tag (a Workflow).** One subagent writes **one concrete prompt per row** instantiating those exact levels, given the agent's purpose / capabilities / tools (seed → expand for diversity, à la Self-Instruct / Evol-Instruct). **Store the row's factor-vector in each example's `metadata`** so failures map back to factor cells after the experiment (which levels actually break the agent). *(Subagents expose no temperature/"creativity" knob — drive diversity via the per-row factor vector + an explicit "maximize diversity, avoid overlap with already-generated cases" instruction, not sampling temp. For true temperature control, generate via a direct model API call in a script.)*
+  - **④ Dedup + coverage check.** Semantic-dedupe near-duplicates (LLMs **mode-collapse**), confirm every cell is filled, balance happy-path vs breakers.
+  - **Why:** stratified / quota sampling (categories = strata) + combinatorial coverage over dimensions — a covering array is the test-design cousin of fractional-factorial / orthogonal arrays, but tuned for *coverage* (every level & pair appears), not unbiased effect estimation, so it fits here better than a Resolution-III design. Dedup fights mode collapse; the adversarial factor probes the tails. **Optimize for representative coverage, not raw count.**
+  - **Per-category guarantee:** pairwise only guarantees each category *appears* (≈ once per the largest other factor). If you need ≥k prompts per category, raise the strength, hold `category` to full coverage while pairwise-ing the rest, or generate the array per-category.
+- **Red-team loop (hardening):** parallel adversarial subagents, each looping until it confirms a *real* break — adds confirmed failures the coverage pass may have missed.
+- Open the dataset URL, show the cases, STOP — let them see the cases before any eval.
+
+**2. What matters → build the evaluators** (`write-tests`).
+- Ask **"what matters to you about this agent?"** — offer dimensions (groundedness, scope, safety, tone…) AND an escape: *"show me some outputs and I'll tell you what's good/bad,"* then derive dimensions from reactions.
+- **Assertions** pattern: each example's `outputs` = `{assertions:[{key,comment}]}`; evaluator returns **one feedback score per assertion key** (LLM-judge). Each key = one Python test, 1-to-1.
+- **Data model (get this right):** the dataset example holds `inputs` (the user query) + **`outputs` = the reference/target** (expected outcome — the `assertions`, plus any expected grounding/citation from reverse-RAG). The agent's **actual** response is **not** written into the dataset — it's produced per-run when you run the experiment (step 3) as the run's output, and the evaluator scores **run-output vs. the example's reference outputs**. (So: target → example reference outputs; actual → experiment run output.)
+
+**3. Score → run the experiment** (`score`). Apply evaluators → per-sample, per-key scores. Surface the experiment URL.
+
+**4. Align the evaluators — "are they any good?"** (`align`) — the TRUST step, gate for everything after.
+- Open the **annotation queue** (user grades the same samples) + **align-evals view** (human vs evaluator → **alignment %**). Iterate until trusted: accept@k · auto-iterate · edit eval prompts (Prompt Hub) · later. **Train/test split** so you don't overfit the judges.
+
+**5. Fix → red→green** (`fix-green`). With trusted evals, **adjust the harness to fix any issues uncovered** at the root; re-run; confirm red→green, nothing regressed. Keep the dataset as a permanent **regression suite**.
+- Opt-in (evals adjudicate, user drives): prompt / tool / harness tuning to raise scores.
+- **3-strike rule:** if 3 fix attempts don't flip a failing key green, STOP — it's likely the wrong layer (architecture, or the eval itself), not the fix. Reconsider or escalate via AskUserQuestion.
+
+**6. Optimize → swap models** (`optimize`). Now that the suite is trusted and green, sweep models to find the **cheapest / best-performing** that still passes.
+- **Resolve `model: choose-for-me` HERE — REQUIRED.** Score candidate models on the eval suite → pick the cheapest passing (or highest-scoring); record `model.name` + `model.resolved:true`. Never silently ship the scaffold default.
+
+**7. Harden the evals** (`harden`).
+- **Cost:** report last experiment cost; offer to reduce it (cheaper judge, fewer/auto-selected cases) — Yes/No/Later.
+- **CI:** recommend a PR-triggered CI gate that runs the suite. If a GitHub repo, offer a PR to verify e2e. Yes/No/Later.
+</flow>


### PR DESCRIPTION
## What
Adds a guided **Agent Development Life Cycle** suite on top of the existing
`langsmith-trace` / `langsmith-dataset` / `langsmith-evaluator` skills:

- **productionalize-agent** — orchestrator; owns shared `.adlc.json` state + conventions, a static teaching curriculum, and an HTML progress card
- **build-agent / test-agent / deploy-agent / monitor-agent / improve-agent** — standalone drop-in phase commands that also run under the orchestrator

## How it works
Each phase is usable on its own (drop in at any lifecycle stage, even on an agent already in production) or run end-to-end via `/productionalize-agent`. Build's exit gate is traces flowing to LangSmith + a verified local `make run`; Test is TDD-for-agents (a dataset + evaluators you trust, then red→green).

## Notes
- Plugin bumped to `0.2.0`; suite documented in `config/AGENTS.md`
- Cross-skill references stay within `config/skills/`, so they survive plugin install
